### PR TITLE
Update archive API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ toolchain go1.24.1
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/briandowns/spinner v1.23.2
-	github.com/cli/safeexec v1.0.1
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/henvic/httpretty v0.1.4
+	github.com/klauspost/compress v1.18.0
 	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/sys/sequential v0.6.0
 	github.com/moby/term v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7r
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
-github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
-github.com/cli/safeexec v1.0.1/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -34,6 +32,8 @@ github.com/henvic/httpretty v0.1.4 h1:Jo7uwIRWVFxkqOnErcoYfH90o3ddQyVrSANeS4cxYm
 github.com/henvic/httpretty v0.1.4/go.mod h1:Dn60sQTZfbt2dYsdUSNsCljyF4AfdqnuJFDLJA1I4AM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -232,6 +232,18 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		return err
 	}
 
+	originalHdrName := hdr.Name
+
+	if originalHdrName == "." {
+		hdr.Name = "package"
+
+		if fi.IsDir() && !strings.HasSuffix(hdr.Name, "/") {
+			hdr.Name += "/"
+		}
+	} else {
+		hdr.Name = filepath.ToSlash(filepath.Join("package", originalHdrName))
+	}
+
 	// if it's not a directory and has more than 1 link,
 	// it's hard linked, so set the type flag accordingly
 	if !fi.IsDir() && hasHardlinks(fi) {
@@ -246,7 +258,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 			hdr.Linkname = oldpath
 			hdr.Size = 0 // This Must be here for the writer math to add up!
 		} else {
-			ta.SeenFiles[inode] = name
+			ta.SeenFiles[inode] = hdr.Name
 		}
 	}
 

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -4,8 +4,6 @@ package archive
 
 import (
 	"os"
-	"path/filepath"
-	"strings"
 	"syscall"
 )
 
@@ -15,18 +13,13 @@ func addLongPathPrefix(srcPath string) string {
 	return srcPath
 }
 
-// getWalkRoot calculates the root path when performing a TarWithOptions.
-// We use a separate function as this is platform specific. On Linux, we
-// can't use filepath.Join(srcPath,include) because this will clean away
-// a trailing "." or "/" which may be important.
-func getWalkRoot(srcPath string, include string) string {
-	return strings.TrimSuffix(srcPath, string(filepath.Separator)) + string(filepath.Separator) + include
-}
-
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
-	return perm // noop for unix as golang APIs provide perm bits correctly
+	// Remove group- and world-writable bits.
+	perm &= ^os.FileMode(0o022)
+
+	return perm
 }
 
 func getInodeFromStat(stat interface{}) (inode uint64, err error) {

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -2,7 +2,6 @@ package archive
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -24,17 +23,11 @@ func addLongPathPrefix(srcPath string) string {
 	return longPathPrefix + srcPath
 }
 
-// getWalkRoot calculates the root path when performing a TarWithOptions.
-// We use a separate function as this is platform specific.
-func getWalkRoot(srcPath string, include string) string {
-	return filepath.Join(srcPath, include)
-}
-
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
 	// Remove group- and world-writable bits.
-	perm &= 0o775
+	perm &= ^os.FileMode(0o022)
 
 	// Add the x bit: make everything +x on Windows
 	return perm | 0o111

--- a/pkg/archive/copy.go
+++ b/pkg/archive/copy.go
@@ -3,8 +3,6 @@ package archive
 import (
 	"errors"
 	"io"
-	"os"
-	"path/filepath"
 	"sync"
 )
 
@@ -25,23 +23,4 @@ func copyWithBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
 
 var copyPool = sync.Pool{
 	New: func() interface{} { s := make([]byte, 32*1024); return &s },
-}
-
-// specifiesCurrentDir returns whether the given path specifies
-// a "current directory", i.e., the last path segment is `.`.
-func specifiesCurrentDir(path string) bool {
-	return filepath.Base(path) == "."
-}
-
-// SplitPathDirEntry splits the given path between its directory name and its
-// basename by first cleaning the path but preserves a trailing "." if the
-// original path specified the current directory.
-func SplitPathDirEntry(path string) (dir, base string) {
-	cleanedPath := filepath.Clean(filepath.FromSlash(path))
-
-	if specifiesCurrentDir(path) {
-		cleanedPath += string(os.PathSeparator) + "."
-	}
-
-	return filepath.Dir(cleanedPath), filepath.Base(cleanedPath)
 }


### PR DESCRIPTION
- Upgrade the archive API to use zstd compression instead of gzip
- Prefix tarball contents with package to avoid tarbombs
- Strip gid, uid, uname, gname in the tar file headers
- Update tar header mode mask to `0o022`