### PR TITLE
Update init commands to handle existing theme and plugins migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ wpm
 !pkg/wpm
 wpm.json
 .wpmignore
+
+# test theme and plugin dir
+amp
+astra

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -136,9 +136,7 @@ func (cli *WpmCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption) er
 		config.SetDir(opts.ConfigDir)
 	}
 
-	if opts.Cwd == "" {
-		opts.Cwd = cliflags.GetWorkingDir(opts.Cwd)
-	}
+	opts.Cwd = cliflags.GetWorkingDir(opts.Cwd)
 
 	if opts.Debug {
 		debug.Enable()

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -30,6 +30,7 @@ type Cli interface {
 	SetIn(in *streams.In)
 	Apply(ops ...CLIOption) error
 	Progress() *progress.Progress
+	Options() *cliflags.ClientOptions
 	ConfigFile() *configfile.ConfigFile
 	RegistryClient() (client.RegistryClient, error)
 }
@@ -116,6 +117,11 @@ func (cli *WpmCli) ConfigFile() *configfile.ConfigFile {
 	return cli.configFile
 }
 
+// Options returns the options used to initialize the cli
+func (cli *WpmCli) Options() *cliflags.ClientOptions {
+	return cli.options
+}
+
 // Initialize the wpmCli runs initialization that must happen after command
 // line flags are parsed.
 func (cli *WpmCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption) error {
@@ -128,6 +134,10 @@ func (cli *WpmCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption) er
 
 	if opts.ConfigDir != "" {
 		config.SetDir(opts.ConfigDir)
+	}
+
+	if opts.Cwd == "" {
+		opts.Cwd = cliflags.GetWorkingDir(opts.Cwd)
 	}
 
 	if opts.Debug {

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"wpm/cli/command"
+	"wpm/pkg/wp/parser"
 	"wpm/pkg/wpm"
 
 	"github.com/morikuni/aec"
@@ -21,7 +23,12 @@ const (
 )
 
 type initOptions struct {
-	yes bool
+	yes         bool
+	name        string
+	version     string
+	migrate     bool
+	license     string
+	packageType string
 }
 
 type prompt struct {
@@ -40,15 +47,23 @@ func NewInitCommand(wpmCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Initialize a new WordPress package",
+		Short: "Initialize a new WordPress package or migrate an existing one",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.migrate {
+				return runMigrate(cmd.Context(), wpmCli, &opts)
+			}
 			return runInit(cmd.Context(), wpmCli, opts)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Skip prompts and use default values")
+	flags.StringVar(&opts.name, "name", "", "Name of the package (for -y, or --migrate)")
+	flags.BoolVarP(&opts.migrate, "migrate", "m", false, "Migrate existing theme or plugin to wpm.json format")
+	flags.StringVar(&opts.license, "license", defaultLicense, "License of the package (default: GPL-2.0-or-later)")
+	flags.StringVar(&opts.version, "version", "", "Version of the package (default: 1.0.0 for init; required for --migrate)")
+	flags.StringVar(&opts.packageType, "type", "", "Type of the package (plugin, theme, mu-plugin). Auto-detected for --migrate if not set.")
 
 	return cmd
 }
@@ -56,15 +71,14 @@ func NewInitCommand(wpmCli command.Cli) *cobra.Command {
 func runInit(ctx context.Context, wpmCli command.Cli, opts initOptions) error {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get current working directory")
 	}
 
-	if _, err = os.Stat(filepath.Join(cwd, wpm.ConfigFile)); err == nil {
-		return errors.New("wpm.json already exists")
-	}
-
-	if !os.IsNotExist(err) {
-		return err
+	wpmConfigFilePath := filepath.Join(cwd, wpm.ConfigFile)
+	if _, err := os.Stat(wpmConfigFilePath); err == nil {
+		return errors.Errorf("%s already exists in %s", wpm.ConfigFile, cwd)
+	} else if !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to check for existing %s", wpm.ConfigFile)
 	}
 
 	basecwd := filepath.Base(cwd)
@@ -78,10 +92,43 @@ func runInit(ctx context.Context, wpmCli command.Cli, opts initOptions) error {
 
 	ve, err := wpm.NewValidator()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to initialize validator")
 	}
 
-	if !opts.yes {
+	if opts.yes {
+		if opts.name == "" {
+			opts.name = basecwd
+		}
+		if errs := ve.Var(opts.name, "required,min=3,max=164,package_name_regex"); errs != nil {
+			return errors.Errorf("invalid package name: \"%s\"", aec.Bold.Apply(opts.name))
+		}
+
+		if opts.version == "" {
+			opts.version = defaultVersion
+		}
+		if errs := ve.Var(opts.version, "required,package_semver,max=64"); errs != nil {
+			return errors.Errorf("invalid version: \"%s\"", aec.Bold.Apply(opts.version))
+		}
+
+		if opts.packageType == "" {
+			opts.packageType = defaultType
+		}
+		if errs := ve.Var(opts.packageType, "required,oneof=plugin theme mu-plugin drop-in"); errs != nil {
+			return errors.Errorf("invalid type: \"%s\"", aec.Bold.Apply(opts.packageType))
+		}
+
+		if opts.license == "" {
+			opts.license = defaultLicense
+		}
+		if errs := ve.Var(opts.license, "required,min=1,max=128"); errs != nil {
+			return errors.Errorf("invalid license: \"%s\"", aec.Bold.Apply(opts.license))
+		}
+
+		wpmJsonInitData.Name = opts.name
+		wpmJsonInitData.License = opts.license
+		wpmJsonInitData.Version = opts.version
+		wpmJsonInitData.Type = opts.packageType
+	} else {
 		prompts := []promptField{
 			{
 				"name",
@@ -171,7 +218,7 @@ func runInit(ctx context.Context, wpmCli command.Cli, opts initOptions) error {
 			for {
 				val, err = command.PromptForInput(ctx, wpmCli.In(), wpmCli.Out(), fmt.Sprintf("%s (%s): ", pf.Prompt.Msg, pf.Prompt.Default))
 				if err != nil {
-					return err
+					return errors.Wrap(err, "failed to get prompt input")
 				}
 
 				if err := pf.Prompt.Validate(val); err != nil {
@@ -184,11 +231,293 @@ func runInit(ctx context.Context, wpmCli command.Cli, opts initOptions) error {
 		}
 	}
 
-	if err := wpm.WriteWpmJson(wpmJsonInitData, ""); err != nil {
+	if err := wpm.WriteWpmJson(wpmJsonInitData, cwd); err != nil {
+		return errors.Wrap(err, "failed to write wpm.json")
+	}
+
+	_, _ = fmt.Fprintf(wpmCli.Out(), "Config created at %s\n", wpmConfigFilePath)
+
+	return nil
+}
+
+type migrationBaseFiles struct {
+	readmeTxt string
+	readmeMd  string
+	wpmJson   string
+}
+
+func findMigrationBaseFiles(cwd string) (migrationBaseFiles, error) {
+	var paths migrationBaseFiles
+	files, err := os.ReadDir(cwd)
+	if err != nil {
+		return paths, errors.Wrap(err, "failed to read current directory")
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		lowerName := strings.ToLower(file.Name())
+		fullPath := filepath.Join(cwd, file.Name())
+
+		switch lowerName {
+		case "readme.txt":
+			paths.readmeTxt = fullPath
+		case "readme.md":
+			paths.readmeMd = fullPath
+		case strings.ToLower(wpm.ConfigFile):
+			paths.wpmJson = fullPath
+		}
+	}
+
+	return paths, nil
+}
+
+func generateReadme(wpmCli command.Cli, readmeTxtPath, readmeMdPath string) (*parser.ReadmeParser, error) {
+	if readmeTxtPath == "" {
+		return nil, errors.New("readme.txt not found in the current directory (required for migration)")
+	}
+
+	readmeTxtContent, err := os.ReadFile(readmeTxtPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read readme.txt")
+	}
+
+	p := parser.NewReadmeParser()
+	p.Parse(string(readmeTxtContent))
+
+	if readmeMdPath == "" {
+		markdownContent := p.ToMarkdown()
+		readmeMdPath := strings.TrimSuffix(readmeTxtPath, filepath.Ext(readmeTxtPath)) + ".md"
+		if err := os.WriteFile(readmeMdPath, []byte(markdownContent), 0644); err != nil {
+			return nil, errors.Wrapf(err, "failed to write %s", readmeMdPath)
+		}
+
+		_, _ = fmt.Fprintf(wpmCli.Out(), "%s created from readme.txt\n", filepath.Base(readmeMdPath))
+	}
+	return p, nil
+}
+
+func findMainPluginFile(cwd string, targetVersion string, files []os.DirEntry) (string, parser.PluginFileHeaders, error) {
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(strings.ToLower(file.Name()), ".php") {
+			continue
+		}
+
+		filePath := filepath.Join(cwd, file.Name())
+		headers, err := parser.GetPluginHeaders(filePath)
+		if err != nil {
+			continue
+		}
+
+		if headers.Version == targetVersion {
+			return filePath, headers, nil
+		}
+	}
+
+	return "", parser.PluginFileHeaders{}, errors.New("no main plugin file with valid plugin headers found")
+}
+
+func getMetaString(meta map[string]interface{}, key string, defaultValue string) string {
+	if val, ok := meta[key]; ok {
+		if strVal, ok := val.(string); ok && strVal != "" {
+			return strVal
+		}
+	}
+	return defaultValue
+}
+
+func getMetaStringSlice(meta map[string]interface{}, key string) []string {
+	if val, ok := meta[key]; ok {
+		if sliceVal, ok := val.([]string); ok {
+			return sliceVal
+		}
+	}
+	return []string{}
+}
+
+func buildWPMConfig(
+	opts initOptions,
+	pkgType string,
+	mainFileHeaders interface{},
+	readmeMeta map[string]interface{},
+) *wpm.Config {
+	cfg := &wpm.Config{
+		Name:        opts.name,
+		Version:     opts.version,
+		Type:        pkgType,
+		License:     getMetaString(readmeMeta, "license", ""),
+		Description: getMetaString(readmeMeta, "meta_description", ""),
+	}
+
+	tags := getMetaStringSlice(readmeMeta, "tags")
+	if len(tags) > 5 {
+		cfg.Tags = tags[:5]
+	} else {
+		cfg.Tags = tags
+	}
+
+	cfg.Team = getMetaStringSlice(readmeMeta, "contributors")
+
+	dependencies := make(map[string]string)
+	wpRequires := getMetaString(readmeMeta, "requires", "")
+	phpRequires := getMetaString(readmeMeta, "requires_php", "")
+
+	switch h := mainFileHeaders.(type) {
+	case parser.ThemeFileHeaders:
+		cfg.Homepage = h.ThemeURI
+		if wpRequires == "" && h.RequiresWP != "" {
+			wpRequires = h.RequiresWP
+		}
+		if phpRequires == "" && h.RequiresPHP != "" {
+			phpRequires = h.RequiresPHP
+		}
+	case parser.PluginFileHeaders:
+		cfg.Homepage = h.PluginURI
+		if wpRequires == "" && h.RequiresWP != "" {
+			wpRequires = h.RequiresWP
+		}
+		if phpRequires == "" && h.RequiresPHP != "" {
+			phpRequires = h.RequiresPHP
+		}
+		if len(h.RequiresPlugins) > 0 {
+			for _, reqPlugin := range h.RequiresPlugins {
+				// Add "*" as version since requires plugins only specify the plugin slug, not a version.
+				dependencies[reqPlugin] = "*"
+			}
+		}
+	}
+
+	if wpRequires != "" {
+		dependencies["wp"] = wpRequires
+	}
+	if phpRequires != "" {
+		dependencies["php"] = phpRequires
+	}
+	if len(dependencies) > 0 {
+		cfg.Dependencies = dependencies
+	}
+
+	return cfg
+}
+
+func runMigrationProcess(wpmCli command.Cli, opts initOptions, cwd string) error {
+	baseFiles, err := findMigrationBaseFiles(cwd)
+	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(wpmCli.Out(), "config created at %s\n", filepath.Join(cwd, wpm.ConfigFile))
+	if baseFiles.wpmJson != "" {
+		_, _ = fmt.Fprintf(wpmCli.Out(), "%s already exists at %s, skipping migration.\n", wpm.ConfigFile, baseFiles.wpmJson)
+		return nil
+	}
+
+	readmeParser, err := generateReadme(wpmCli, baseFiles.readmeTxt, baseFiles.readmeMd)
+	if err != nil {
+		return err
+	}
+
+	readmeMetadata := readmeParser.GetMetadata()
+
+	var mainFilePath string
+	var mainFileHeaders interface{}
+	var mainFileNameForMsg string // style.css for themes, main plugin file for plugins
+
+	if opts.packageType == "theme" {
+		mainFileNameForMsg = "style.css"
+		mainFilePath = filepath.Join(cwd, mainFileNameForMsg)
+		if _, statErr := os.Stat(mainFilePath); statErr != nil {
+			if os.IsNotExist(statErr) {
+				return errors.Errorf("%s not found in %s", mainFileNameForMsg, cwd)
+			}
+			return errors.Wrapf(statErr, "failed to stat %s", mainFileNameForMsg)
+		}
+
+		headers, parseErr := parser.GetThemeHeaders(mainFilePath)
+		if parseErr != nil {
+			return errors.Wrapf(parseErr, "failed to parse theme headers from %s", mainFileNameForMsg)
+		}
+		if headers.Version != opts.version {
+			return errors.Errorf("version in %s (%s) does not match specified version %s", mainFileNameForMsg, headers.Version, opts.version)
+		}
+
+		mainFileHeaders = headers
+	} else if opts.packageType == "plugin" {
+		dirEntries, readDirErr := os.ReadDir(cwd)
+		if readDirErr != nil {
+			return errors.Wrap(readDirErr, "failed to read current directory for plugin files")
+		}
+
+		foundPath, parsedHeaders, findErr := findMainPluginFile(cwd, opts.version, dirEntries)
+		if findErr != nil {
+			return errors.Wrap(findErr, "failed to identify main plugin file")
+		}
+
+		mainFilePath = foundPath
+		mainFileNameForMsg = filepath.Base(mainFilePath)
+		if parsedHeaders.Version != opts.version { // findMainPluginFile might return a non-matching version if no exact match found
+			return errors.Errorf("version in %s (%s) does not match specified version --version %s", mainFileNameForMsg, parsedHeaders.Version, opts.version)
+		}
+
+		mainFileHeaders = parsedHeaders
+	} else {
+		return errors.Errorf("unsupported package type for migration: %s", opts.packageType)
+	}
+
+	wpmJsonData := buildWPMConfig(opts, opts.packageType, mainFileHeaders, readmeMetadata)
+
+	if err := wpm.WriteWpmJson(wpmJsonData, cwd); err != nil {
+		return errors.Wrapf(err, "failed to write %s", wpm.ConfigFile)
+	}
+
+	_, _ = fmt.Fprintf(wpmCli.Out(), "%s created at %s\n", wpm.ConfigFile, filepath.Join(cwd, wpm.ConfigFile))
 
 	return nil
+}
+
+func getMigrateType(cwd string) string {
+	if _, err := os.Stat(filepath.Join(cwd, "style.css")); err == nil {
+		return "theme"
+	}
+
+	return "plugin"
+}
+
+func runMigrate(ctx context.Context, wpmCli command.Cli, opts *initOptions) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "failed to get current working directory")
+	}
+
+	if opts.name == "" {
+		return errors.Errorf("package --name is required for migration (e.g., --name=amp)")
+	}
+
+	if opts.version == "" {
+		return errors.New("package --version is required for migration (e.g., --version=1.0.0)")
+	}
+
+	if opts.packageType == "" {
+		opts.packageType = getMigrateType(cwd)
+
+		_, _ = fmt.Fprintf(wpmCli.Out(), "Auto-detected package type: %s\n", opts.packageType)
+	}
+
+	if opts.packageType != "theme" && opts.packageType != "plugin" {
+		return errors.Errorf("invalid package type '%s' specified for migration; must be 'theme' or 'plugin'", opts.packageType)
+	}
+
+	ve, err := wpm.NewValidator()
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize validator for migration")
+	}
+	if errs := ve.Var(opts.name, "required,min=3,max=164,package_name_regex"); errs != nil {
+		return errors.Errorf("invalid --name for migration: \"%s\"", aec.Bold.Apply(opts.name))
+	}
+	if errs := ve.Var(opts.version, "required,package_semver,max=64"); errs != nil {
+		return errors.Errorf("invalid --version for migration: \"%s\"", aec.Bold.Apply(opts.version))
+	}
+
+	return runMigrationProcess(wpmCli, *opts, cwd)
 }

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -70,10 +70,7 @@ func NewInitCommand(wpmCli command.Cli) *cobra.Command {
 }
 
 func runInit(ctx context.Context, wpmCli command.Cli, opts initOptions) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "failed to get current working directory")
-	}
+	cwd := wpmCli.Options().Cwd
 
 	wpmConfigFilePath := filepath.Join(cwd, wpm.ConfigFile)
 	if _, err := os.Stat(wpmConfigFilePath); err == nil {
@@ -492,10 +489,7 @@ func getMigrateType(cwd string) string {
 }
 
 func runMigrate(ctx context.Context, wpmCli command.Cli, opts *initOptions) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "failed to get current working directory")
-	}
+	cwd := wpmCli.Options().Cwd
 
 	if opts.name == "" {
 		return errors.Errorf("package --name is required for migration (e.g., --name=amp)")

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -11,6 +11,7 @@ import (
 	"wpm/pkg/wp/parser"
 	"wpm/pkg/wpm"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -390,10 +391,16 @@ func buildWPMConfig(
 	}
 
 	if wpRequires != "" {
-		dependencies["wp"] = wpRequires
+		v, err := semver.NewVersion(wpRequires)
+		if err == nil {
+			dependencies["wp"] = v.String()
+		}
 	}
 	if phpRequires != "" {
-		dependencies["php"] = phpRequires
+		v, err := semver.NewVersion(phpRequires)
+		if err == nil {
+			dependencies["php"] = v.String()
+		}
 	}
 	if len(dependencies) > 0 {
 		cfg.Dependencies = dependencies

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -471,6 +471,13 @@ func runMigrationProcess(wpmCli command.Cli, opts initOptions, cwd string) error
 
 	wpmJsonData := buildWPMConfig(opts, opts.packageType, mainFileHeaders, readmeMetadata)
 
+	v, err := semver.NewVersion(wpmJsonData.Version)
+	if err != nil {
+		return errors.Wrapf(err, "invalid version %s; must be a valid semantic version", wpmJsonData.Version)
+	}
+
+	wpmJsonData.Version = v.String()
+
 	if err := wpm.WriteWpmJson(wpmJsonData, cwd); err != nil {
 		return errors.Wrapf(err, "failed to write %s", wpm.ConfigFile)
 	}
@@ -502,7 +509,7 @@ func runMigrate(ctx context.Context, wpmCli command.Cli, opts *initOptions) erro
 	if opts.packageType == "" {
 		opts.packageType = getMigrateType(cwd)
 
-		_, _ = fmt.Fprintf(wpmCli.Out(), "Auto-detected package type: %s\n", opts.packageType)
+		_, _ = fmt.Fprintf(wpmCli.Out(), "auto-detected package type: %s\n", opts.packageType)
 	}
 
 	if opts.packageType != "theme" && opts.packageType != "plugin" {
@@ -516,7 +523,7 @@ func runMigrate(ctx context.Context, wpmCli command.Cli, opts *initOptions) erro
 	if errs := ve.Var(opts.name, "required,min=3,max=164,package_name_regex"); errs != nil {
 		return errors.Errorf("invalid --name for migration: \"%s\"", aec.Bold.Apply(opts.name))
 	}
-	if errs := ve.Var(opts.version, "required,package_semver,max=64"); errs != nil {
+	if errs := ve.Var(opts.version, "required,max=64"); errs != nil {
 		return errors.Errorf("invalid --version for migration: \"%s\"", aec.Bold.Apply(opts.version))
 	}
 

--- a/cli/command/install/install.go
+++ b/cli/command/install/install.go
@@ -2,7 +2,6 @@ package install
 
 import (
 	"context"
-	"os"
 
 	"wpm/cli"
 	"wpm/cli/command"
@@ -38,14 +37,10 @@ func NewInstallCommand(wpmCli command.Cli) *cobra.Command {
 }
 
 func runInstall(ctx context.Context, wpmCli command.Cli, opts installOptions) error {
-	var err error
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
+	cwd := wpmCli.Options().Cwd
 
 	// @todo: complete the install command
-	_, err = wpm.ReadAndValidateWpmJson(cwd)
+	_, err := wpm.ReadAndValidateWpmJson(cwd)
 	if err != nil {
 		return err
 	}

--- a/cli/command/publish/publish.go
+++ b/cli/command/publish/publish.go
@@ -186,7 +186,7 @@ func runPublish(wpmCli command.Cli, opts publishOptions) error {
 				UnpackedSize: tarball.UnpackedSize(),
 			},
 			Tag:        opts.tag,
-			Access:     opts.access,
+			Visibility: opts.access,
 			Attachment: base64.StdEncoding.EncodeToString(buf.Bytes()),
 			Readme:     readme,
 			Wpm:        ver,

--- a/cli/command/publish/publish.go
+++ b/cli/command/publish/publish.go
@@ -91,6 +91,8 @@ func readme(path string) (string, error) {
 }
 
 func runPublish(wpmCli command.Cli, opts publishOptions) error {
+	cwd := wpmCli.Options().Cwd
+
 	if opts.access != "public" && opts.access != "private" {
 		return errors.New("access must be either public or private")
 	}
@@ -98,11 +100,6 @@ func runPublish(wpmCli command.Cli, opts publishOptions) error {
 	cfg := wpmCli.ConfigFile()
 	if cfg.AuthToken == "" {
 		return errors.New("user must be logged in to perform this action")
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
 	}
 
 	wpmJson, err := wpm.ReadAndValidateWpmJson(cwd)

--- a/cli/flags/options.go
+++ b/cli/flags/options.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"wpm/pkg/config"
 
@@ -61,6 +62,13 @@ func GetWorkingDir(cwd string) string {
 			fmt.Fprintf(os.Stderr, "Invalid working directory: %s\n", cwd)
 			os.Exit(1)
 		}
+
+		cwd, err := filepath.Abs(cwd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to resolve absolute path for cwd: %s\n", cwd)
+			os.Exit(1)
+		}
+
 		return cwd
 	}
 

--- a/cli/flags/options.go
+++ b/cli/flags/options.go
@@ -15,6 +15,7 @@ type ClientOptions struct {
 	Debug     bool
 	LogLevel  string
 	ConfigDir string
+	Cwd       string
 }
 
 // NewClientOptions returns a new ClientOptions.
@@ -26,8 +27,9 @@ func NewClientOptions() *ClientOptions {
 func (o *ClientOptions) InstallFlags(flags *pflag.FlagSet) {
 	configDir := config.Dir()
 
-	flags.StringVar(&o.ConfigDir, "config", configDir, "Location of client config files")
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
+	flags.StringVar(&o.Cwd, "cwd", "", "Set the current working directory")
+	flags.StringVar(&o.ConfigDir, "config", configDir, "Location of client config files")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug", "info", "warn", "error", "fatal")`)
 }
 
@@ -47,4 +49,26 @@ func SetLogLevel(logLevel string) {
 	} else {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
+}
+
+// GetWorkingDir returns the working directory for the client.
+// By default recurse to root, find wpm.json and return the directory
+// containing it. If cwd is provided, it returns that directory.
+// If none, fallback to the current working directory.
+func GetWorkingDir(cwd string) string {
+	if cwd != "" {
+		if _, err := os.Stat(cwd); err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid working directory: %s\n", cwd)
+			os.Exit(1)
+		}
+		return cwd
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get current working directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	return cwd
 }

--- a/pkg/wp/parser/readme-txt.go
+++ b/pkg/wp/parser/readme-txt.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"io"
 	"regexp"
 	"sort"
 	"strconv"
@@ -58,7 +57,7 @@ func NewReadmeParser() *ReadmeParser {
 }
 
 // Parse reads and parses the readme.txt content.
-func (p *ReadmeParser) Parse(content string) error {
+func (p *ReadmeParser) Parse(content string) {
 	normalizedContent := strings.ReplaceAll(content, "\r\n", "\n")
 	normalizedContent = strings.ReplaceAll(normalizedContent, "\r", "\n")
 	lines := strings.Split(normalizedContent, "\n")
@@ -81,8 +80,6 @@ func (p *ReadmeParser) Parse(content string) error {
 	lineIndex = p.parseMetaDescription(lines, lineIndex)
 	p.parseSections(lines, lineIndex)
 	p.processSpecialSections()
-
-	return nil
 }
 
 func (p *ReadmeParser) stripBOM(lines []string) []string {
@@ -459,18 +456,4 @@ func (p *ReadmeParser) GetMetadata() map[string]interface{} {
 		"license_uri":      p.LicenseURI,
 		"donate_link":      p.DonateLink,
 	}
-}
-
-func ConvertReadmeToMarkdown(input io.Reader) (string, error) {
-	contentBytes, err := io.ReadAll(input)
-	if err != nil {
-		return "", fmt.Errorf("failed to read input: %w", err)
-	}
-
-	parser := NewReadmeParser()
-	if err := parser.Parse(string(contentBytes)); err != nil {
-		return "", fmt.Errorf("failed to parse readme content: %w", err)
-	}
-
-	return parser.ToMarkdown(), nil
 }

--- a/pkg/wp/parser/readme-txt.go
+++ b/pkg/wp/parser/readme-txt.go
@@ -1,0 +1,476 @@
+package parser
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// Constants for known section keys.
+const (
+	sectionDescription              = "description"
+	sectionInstallation             = "installation"
+	sectionFAQ                      = "faq"
+	sectionFrequentlyAskedQuestions = "frequently_asked_questions"
+	sectionScreenshots              = "screenshots"
+	sectionScreenshot               = "screenshot"
+	sectionChangelog                = "changelog"
+	sectionChangeLog                = "change_log"
+	sectionUpgradeNotice            = "upgrade_notice"
+)
+
+var (
+	screenshotLineRegex = regexp.MustCompile(`^(\d+)\.\s+(.+)$`)
+)
+
+type ReadmeParser struct {
+	Name            string
+	MetaDescription string
+	Contributors    []string
+	Tags            []string
+	Requires        string
+	Tested          string
+	RequiresPHP     string
+	StableTag       string
+	License         string
+	LicenseURI      string
+	DonateLink      string
+
+	Sections      map[string]string
+	Screenshots   map[int]string
+	FAQ           map[string]string
+	UpgradeNotice map[string]string
+}
+
+func NewReadmeParser() *ReadmeParser {
+	return &ReadmeParser{
+		Sections:      make(map[string]string),
+		Screenshots:   make(map[int]string),
+		FAQ:           make(map[string]string),
+		UpgradeNotice: make(map[string]string),
+	}
+}
+
+// Parse reads and parses the readme.txt content.
+func (p *ReadmeParser) Parse(content string) error {
+	normalizedContent := strings.ReplaceAll(content, "\r\n", "\n")
+	normalizedContent = strings.ReplaceAll(normalizedContent, "\r", "\n")
+	lines := strings.Split(normalizedContent, "\n")
+
+	lines = p.stripBOM(lines)
+
+	lineIndex := 0
+
+	// Parse plugin name from === Plugin Name ===
+	lineIndex = p.skipEmptyLines(lines, lineIndex)
+	if lineIndex < len(lines) {
+		trimmedLine := strings.TrimSpace(lines[lineIndex])
+		if strings.HasPrefix(trimmedLine, "===") && strings.HasSuffix(trimmedLine, "===") && len(trimmedLine) > 6 { // e.g. "===A==="
+			p.Name = p.parsePluginName(trimmedLine)
+			lineIndex++
+		}
+	}
+
+	lineIndex = p.parseHeaders(lines, lineIndex)
+	lineIndex = p.parseMetaDescription(lines, lineIndex)
+	p.parseSections(lines, lineIndex)
+	p.processSpecialSections()
+
+	return nil
+}
+
+func (p *ReadmeParser) stripBOM(lines []string) []string {
+	if len(lines) > 0 && strings.HasPrefix(lines[0], "\xEF\xBB\xBF") {
+		lines[0] = strings.TrimPrefix(lines[0], "\xEF\xBB\xBF")
+	}
+	return lines
+}
+
+// parsePluginName extracts the plugin name.
+func (p *ReadmeParser) parsePluginName(line string) string {
+	name := strings.TrimPrefix(line, "===")
+	name = strings.TrimSuffix(name, "===")
+	return strings.TrimSpace(name)
+}
+
+func (p *ReadmeParser) skipEmptyLines(lines []string, start int) int {
+	for i := start; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != "" {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+func parseCommaSeparatedList(value string) []string {
+	items := strings.Split(value, ",")
+	var result []string
+	for _, item := range items {
+		trimmedItem := strings.TrimSpace(item)
+		if trimmedItem != "" {
+			result = append(result, trimmedItem)
+		}
+	}
+	return result
+}
+
+func (p *ReadmeParser) parseHeaders(lines []string, start int) int {
+	// Map of accepted header strings (lowercase) to a canonical key.
+	validHeaders := map[string]string{
+		"tested up to":      "tested",
+		"tested":            "tested",
+		"requires at least": "requires",
+		"requires":          "requires",
+		"requires php":      "requires_php",
+		"tags":              "tags",
+		"contributors":      "contributors",
+		"donate link":       "donate_link",
+		"stable tag":        "stable_tag",
+		"license":           "license",
+		"license uri":       "license_uri",
+	}
+
+	i := start
+	for i < len(lines) {
+		lineContent := lines[i]
+		trimmedLine := strings.TrimSpace(lineContent)
+
+		if trimmedLine == "" {
+			i++
+			continue
+		}
+
+		// Headers end when a section (==) or plugin title (===) starts.
+		if strings.HasPrefix(trimmedLine, "==") {
+			break
+		}
+
+		if strings.Contains(lineContent, ":") {
+			parts := strings.SplitN(lineContent, ":", 2)
+			// Ensure key part is not empty after trimming
+			if len(parts) == 2 && strings.TrimSpace(parts[0]) != "" {
+				key := strings.ToLower(strings.TrimSpace(parts[0]))
+				value := strings.TrimSpace(parts[1])
+
+				if canonicalKey, ok := validHeaders[key]; ok {
+					switch canonicalKey {
+					case "contributors":
+						p.Contributors = parseCommaSeparatedList(value)
+					case "tags":
+						p.Tags = parseCommaSeparatedList(value)
+					case "requires":
+						p.Requires = value
+					case "tested":
+						p.Tested = value
+					case "requires_php":
+						p.RequiresPHP = value
+					case "stable_tag":
+						p.StableTag = value
+					case "license":
+						p.License = value
+					case "license_uri":
+						p.LicenseURI = value
+					case "donate_link":
+						p.DonateLink = value
+					}
+				}
+			} else {
+				// Malformed header (e.g., "Key:" with no value, or ": value"), end of headers.
+				break
+			}
+		} else {
+			// Line does not contain ':' and is not empty, so it's not a header.
+			break
+		}
+		i++
+	}
+	return i
+}
+
+func (p *ReadmeParser) parseMetaDescription(lines []string, start int) int {
+	i := p.skipEmptyLines(lines, start)
+
+	if i < len(lines) {
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(line, "==") {
+			p.MetaDescription = line
+			i++
+		}
+	}
+	return i
+}
+
+func (p *ReadmeParser) parseSections(lines []string, start int) {
+	var currentSectionKey string
+	var currentContent strings.Builder
+
+	saveSection := func() {
+		if currentSectionKey != "" {
+			// Trim only leading/trailing newlines from the collected content block.
+			content := strings.Trim(currentContent.String(), "\n")
+			p.Sections[currentSectionKey] = content
+			currentContent.Reset()
+		}
+	}
+
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		trimmedLine := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmedLine, "==") && strings.HasSuffix(trimmedLine, "==") &&
+			!strings.HasPrefix(trimmedLine, "===") && len(trimmedLine) >= 4 { // Min: "== =="
+			saveSection()
+			sectionTitle := strings.TrimSpace(trimmedLine[2 : len(trimmedLine)-2])
+			currentSectionKey = strings.ToLower(strings.ReplaceAll(sectionTitle, " ", "_"))
+		} else {
+			if currentSectionKey != "" {
+				currentContent.WriteString(line + "\n")
+			}
+		}
+	}
+	saveSection()
+}
+
+// getSectionContent retrieves section content, checking primary and alternative keys.
+func (p *ReadmeParser) getSectionContent(primaryKey string, alternateKeys ...string) (content string, keyUsed string, found bool) {
+	if content, ok := p.Sections[primaryKey]; ok {
+		return content, primaryKey, true
+	}
+	for _, altKey := range alternateKeys {
+		if content, ok := p.Sections[altKey]; ok {
+			return content, altKey, true
+		}
+	}
+	return "", "", false
+}
+
+func (p *ReadmeParser) processSpecialSections() {
+	if faqContent, _, ok := p.getSectionContent(sectionFrequentlyAskedQuestions, sectionFAQ); ok && faqContent != "" {
+		p.FAQ = p.parseBlockStyleItems(faqContent)
+	}
+
+	if screenshotsContent, _, ok := p.getSectionContent(sectionScreenshots, sectionScreenshot); ok && screenshotsContent != "" {
+		p.parseScreenshots(screenshotsContent)
+	}
+
+	if upgradeContent, _, ok := p.getSectionContent(sectionUpgradeNotice); ok && upgradeContent != "" {
+		p.UpgradeNotice = p.parseBlockStyleItems(upgradeContent)
+	}
+}
+
+// parseBlockStyleItems parses sections like FAQ or UpgradeNotice where items are "= Item Title =".
+func (p *ReadmeParser) parseBlockStyleItems(content string) map[string]string {
+	itemsMap := make(map[string]string)
+	lines := strings.Split(content, "\n")
+	var currentItemTitle string
+	var currentItemContent strings.Builder
+
+	saveItem := func() {
+		if currentItemTitle != "" {
+			itemsMap[currentItemTitle] = strings.Trim(currentItemContent.String(), "\n")
+			currentItemContent.Reset()
+		}
+	}
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmedLine, "=") && strings.HasSuffix(trimmedLine, "=") &&
+			!strings.HasPrefix(trimmedLine, "==") && len(trimmedLine) >= 3 { // Min: "=A=" or "= ="
+			saveItem()
+			currentItemTitle = strings.TrimSpace(trimmedLine[1 : len(trimmedLine)-1])
+		} else if currentItemTitle != "" { // Only append if we have an active item title
+			currentItemContent.WriteString(line + "\n")
+		}
+	}
+	saveItem()
+	return itemsMap
+}
+
+func (p *ReadmeParser) parseScreenshots(content string) {
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
+			continue
+		}
+		if matches := screenshotLineRegex.FindStringSubmatch(trimmedLine); len(matches) == 3 {
+			num, err := strconv.Atoi(matches[1])
+			if err == nil && num > 0 {
+				p.Screenshots[num] = strings.TrimSpace(matches[2])
+			}
+		}
+	}
+}
+
+func (p *ReadmeParser) convertSubsections(content string) string {
+	lines := strings.Split(content, "\n")
+	var result strings.Builder
+	for i, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "=") && strings.HasSuffix(trimmedLine, "=") &&
+			!strings.HasPrefix(trimmedLine, "==") && len(trimmedLine) >= 3 {
+			subsectionTitle := strings.TrimSpace(trimmedLine[1 : len(trimmedLine)-1])
+			result.WriteString("### " + subsectionTitle)
+		} else {
+			result.WriteString(line)
+		}
+		if i < len(lines)-1 {
+			result.WriteString("\n")
+		}
+	}
+	return result.String()
+}
+
+type sectionToMarkdownConfig struct {
+	markdownTitle string
+	primaryKey    string
+	alternateKeys []string
+	render        func(parser *ReadmeParser, rawSectionContent string, md *strings.Builder) (handled bool)
+}
+
+func renderFAQMarkdown(parser *ReadmeParser, _ string, md *strings.Builder) bool {
+	if len(parser.FAQ) > 0 {
+		questions := make([]string, 0, len(parser.FAQ))
+		for q := range parser.FAQ {
+			questions = append(questions, q)
+		}
+		sort.Strings(questions)
+		for _, question := range questions {
+			md.WriteString("### " + question + "\n\n")
+			md.WriteString(parser.FAQ[question] + "\n\n")
+		}
+		return true
+	}
+	return false
+}
+
+func renderScreenshotsMarkdown(parser *ReadmeParser, _ string, md *strings.Builder) bool {
+	if len(parser.Screenshots) > 0 {
+		keys := make([]int, 0, len(parser.Screenshots))
+		for k := range parser.Screenshots {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+		for _, k := range keys {
+			md.WriteString(fmt.Sprintf("%d. %s\n", k, parser.Screenshots[k]))
+		}
+		md.WriteString("\n") // Extra newline after the list
+		return true
+	}
+	return false
+}
+
+func renderUpgradeNoticeMarkdown(parser *ReadmeParser, _ string, md *strings.Builder) bool {
+	if len(parser.UpgradeNotice) > 0 {
+		versions := make([]string, 0, len(parser.UpgradeNotice))
+		for v := range parser.UpgradeNotice {
+			versions = append(versions, v)
+		}
+		sort.Strings(versions) // Note: simple string sort for versions
+		for _, version := range versions {
+			md.WriteString("### " + version + "\n\n")
+			md.WriteString(parser.UpgradeNotice[version] + "\n\n")
+		}
+		return true
+	}
+	return false
+}
+
+func (p *ReadmeParser) ToMarkdown() string {
+	var md strings.Builder
+
+	standardSectionConfigs := []sectionToMarkdownConfig{
+		{markdownTitle: "## Description", primaryKey: sectionDescription},
+		{markdownTitle: "## Installation", primaryKey: sectionInstallation},
+		{markdownTitle: "## Frequently Asked Questions", primaryKey: sectionFrequentlyAskedQuestions, alternateKeys: []string{sectionFAQ}, render: renderFAQMarkdown},
+		{markdownTitle: "## Screenshots", primaryKey: sectionScreenshots, alternateKeys: []string{sectionScreenshot}, render: renderScreenshotsMarkdown},
+		{markdownTitle: "## Changelog", primaryKey: sectionChangelog, alternateKeys: []string{sectionChangeLog}},
+		{markdownTitle: "## Upgrade Notice", primaryKey: sectionUpgradeNotice, render: renderUpgradeNoticeMarkdown},
+	}
+
+	renderedSectionKeys := make(map[string]bool)
+
+	for _, config := range standardSectionConfigs {
+		content, keyUsed, found := p.getSectionContent(config.primaryKey, config.alternateKeys...)
+
+		// If not found, or found but the content is empty, skip rendering its title/content.
+		// Mark as "handled" if found (even if empty) to prevent it appearing in "Other sections".
+		if !found {
+			continue
+		}
+		renderedSectionKeys[keyUsed] = true // Mark key as handled
+		if content == "" {
+			continue // Don't render title for empty sections
+		}
+
+		md.WriteString(config.markdownTitle + "\n\n")
+
+		handledByCustomRender := false
+		if config.render != nil {
+			handledByCustomRender = config.render(p, content, &md)
+		}
+		if !handledByCustomRender {
+			md.WriteString(p.convertSubsections(content) + "\n\n")
+		}
+	}
+
+	// Process "Other sections"
+	otherSectionKeys := make([]string, 0, len(p.Sections))
+	for key := range p.Sections {
+		if !renderedSectionKeys[key] {
+			otherSectionKeys = append(otherSectionKeys, key)
+		}
+	}
+	sort.Strings(otherSectionKeys) // Sort for consistent output
+
+	titleCaser := cases.Title(language.English)
+	for _, sectionKey := range otherSectionKeys {
+		content := p.Sections[sectionKey]
+		if content == "" { // Should not happen if `renderedSectionKeys` logic is correct for empty sections
+			continue
+		}
+		// Convert snake_case_key to Title Case
+		title := titleCaser.String(strings.ReplaceAll(sectionKey, "_", " "))
+		md.WriteString("## " + title + "\n\n")
+		md.WriteString(p.convertSubsections(content) + "\n\n")
+	}
+
+	return strings.TrimSpace(md.String())
+}
+
+func (p *ReadmeParser) GetMetadata() map[string]interface{} {
+	return map[string]interface{}{
+		"name":             p.Name,
+		"meta_description": p.MetaDescription,
+		"contributors":     p.Contributors,
+		"tags":             p.Tags,
+		"requires":         p.Requires,
+		"tested":           p.Tested,
+		"requires_php":     p.RequiresPHP,
+		"stable_tag":       p.StableTag,
+		"license":          p.License,
+		"license_uri":      p.LicenseURI,
+		"donate_link":      p.DonateLink,
+	}
+}
+
+func ConvertReadmeToMarkdown(input io.Reader) (string, error) {
+	contentBytes, err := io.ReadAll(input)
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	parser := NewReadmeParser()
+	if err := parser.Parse(string(contentBytes)); err != nil {
+		return "", fmt.Errorf("failed to parse readme content: %w", err)
+	}
+
+	return parser.ToMarkdown(), nil
+}

--- a/pkg/wp/parser/wp-file-header.go
+++ b/pkg/wp/parser/wp-file-header.go
@@ -15,69 +15,33 @@ const (
 )
 
 type PluginFileHeaders struct {
-	Name            string
 	PluginURI       string
 	Version         string
-	Description     string
-	Author          string
-	AuthorURI       string
-	TextDomain      string
-	DomainPath      string
-	Network         bool
 	RequiresPHP     string
 	RequiresWP      string
-	UpdateURI       string
-	RequiresPlugins string
+	RequiresPlugins []string
 }
 
 var pluginFileHeaders = map[string]string{
-	"Name":            "Plugin Name",
 	"PluginURI":       "Plugin URI",
 	"Version":         "Version",
-	"Description":     "Description",
-	"Author":          "Author",
-	"AuthorURI":       "Author URI",
-	"TextDomain":      "Text Domain",
-	"DomainPath":      "Domain Path",
-	"Network":         "Network",
-	"RequiresWP":      "Requires at least",
 	"RequiresPHP":     "Requires PHP",
-	"UpdateURI":       "Update URI",
+	"RequiresWP":      "Requires at least",
 	"RequiresPlugins": "Requires Plugins",
 }
 
 type ThemeFileHeaders struct {
-	Name        string
 	ThemeURI    string
-	Description string
-	Author      string
-	AuthorURI   string
 	Version     string
-	Template    string
-	Status      string
-	Tags        string
-	TextDomain  string
-	DomainPath  string
 	RequiresWP  string
 	RequiresPHP string
-	UpdateURI   string
 }
 
 var themeFileHeaders = map[string]string{
-	"Name":        "Theme Name",
 	"ThemeURI":    "Theme URI",
-	"Description": "Description",
-	"Author":      "Author",
-	"AuthorURI":   "Author URI",
 	"Version":     "Version",
-	"Template":    "Template",
-	"Status":      "Status",
-	"Tags":        "Tags",
-	"TextDomain":  "Text Domain",
-	"DomainPath":  "Domain Path",
 	"RequiresWP":  "Requires at least",
 	"RequiresPHP": "Requires PHP",
-	"UpdateURI":   "Update URI",
 }
 
 var headerCleanupRe = regexp.MustCompile(`\s*(?:\*\/|\?>).*`)
@@ -153,22 +117,11 @@ func GetPluginHeaders(filePath string) (PluginFileHeaders, error) {
 	}
 
 	headers := PluginFileHeaders{}
-	headers.Name = rawHeaders["Name"]
 	headers.PluginURI = rawHeaders["PluginURI"]
 	headers.Version = rawHeaders["Version"]
-	headers.Description = rawHeaders["Description"]
-	headers.Author = rawHeaders["Author"]
-	headers.AuthorURI = rawHeaders["AuthorURI"]
-	headers.TextDomain = rawHeaders["TextDomain"]
-	headers.DomainPath = rawHeaders["DomainPath"]
-	networkVal := rawHeaders["Network"]
-	if networkVal == "true" || networkVal == "1" {
-		headers.Network = true
-	}
 	headers.RequiresWP = rawHeaders["RequiresWP"]
 	headers.RequiresPHP = rawHeaders["RequiresPHP"]
-	headers.UpdateURI = rawHeaders["UpdateURI"]
-	headers.RequiresPlugins = rawHeaders["RequiresPlugins"]
+	headers.RequiresPlugins = parseCommaSeparatedList(rawHeaders["RequiresPlugins"])
 
 	return headers, nil
 }
@@ -184,20 +137,10 @@ func GetThemeHeaders(filePath string) (ThemeFileHeaders, error) {
 	}
 
 	headers := ThemeFileHeaders{}
-	headers.Name = rawHeaders["Name"]
 	headers.ThemeURI = rawHeaders["ThemeURI"]
-	headers.Description = rawHeaders["Description"]
-	headers.Author = rawHeaders["Author"]
-	headers.AuthorURI = rawHeaders["AuthorURI"]
 	headers.Version = rawHeaders["Version"]
-	headers.Template = rawHeaders["Template"]
-	headers.Status = rawHeaders["Status"]
-	headers.Tags = rawHeaders["Tags"]
-	headers.TextDomain = rawHeaders["TextDomain"]
-	headers.DomainPath = rawHeaders["DomainPath"]
 	headers.RequiresWP = rawHeaders["RequiresWP"]
 	headers.RequiresPHP = rawHeaders["RequiresPHP"]
-	headers.UpdateURI = rawHeaders["UpdateURI"]
 
 	return headers, nil
 }

--- a/pkg/wp/parser/wp-file-header.go
+++ b/pkg/wp/parser/wp-file-header.go
@@ -1,0 +1,203 @@
+package parser
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	phpFileExtension = ".php"
+	cssFileExtension = ".css"
+	maxHeaderBytes   = 8 * 1024
+)
+
+type PluginFileHeaders struct {
+	Name            string
+	PluginURI       string
+	Version         string
+	Description     string
+	Author          string
+	AuthorURI       string
+	TextDomain      string
+	DomainPath      string
+	Network         bool
+	RequiresPHP     string
+	RequiresWP      string
+	UpdateURI       string
+	RequiresPlugins string
+}
+
+var pluginFileHeaders = map[string]string{
+	"Name":            "Plugin Name",
+	"PluginURI":       "Plugin URI",
+	"Version":         "Version",
+	"Description":     "Description",
+	"Author":          "Author",
+	"AuthorURI":       "Author URI",
+	"TextDomain":      "Text Domain",
+	"DomainPath":      "Domain Path",
+	"Network":         "Network",
+	"RequiresWP":      "Requires at least",
+	"RequiresPHP":     "Requires PHP",
+	"UpdateURI":       "Update URI",
+	"RequiresPlugins": "Requires Plugins",
+}
+
+type ThemeFileHeaders struct {
+	Name        string
+	ThemeURI    string
+	Description string
+	Author      string
+	AuthorURI   string
+	Version     string
+	Template    string
+	Status      string
+	Tags        string
+	TextDomain  string
+	DomainPath  string
+	RequiresWP  string
+	RequiresPHP string
+	UpdateURI   string
+}
+
+var themeFileHeaders = map[string]string{
+	"Name":        "Theme Name",
+	"ThemeURI":    "Theme URI",
+	"Description": "Description",
+	"Author":      "Author",
+	"AuthorURI":   "Author URI",
+	"Version":     "Version",
+	"Template":    "Template",
+	"Status":      "Status",
+	"Tags":        "Tags",
+	"TextDomain":  "Text Domain",
+	"DomainPath":  "Domain Path",
+	"RequiresWP":  "Requires at least",
+	"RequiresPHP": "Requires PHP",
+	"UpdateURI":   "Update URI",
+}
+
+var headerCleanupRe = regexp.MustCompile(`\s*(?:\*\/|\?>).*`)
+
+// getRawFileHeaders reads the first part of a file and extracts raw header values.
+// Returns nil map if filePath has wrong extension or does not exist.
+func getRawFileHeaders(filePath string, expectedExtension string, headerSpecs map[string]string) (map[string]string, error) {
+	if len(filePath) < len(expectedExtension)+1 || filePath[len(filePath)-len(expectedExtension):] != expectedExtension {
+		return nil, nil
+	}
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		// Mimic PHP's behavior of proceeding with empty data on most read failures.
+		return processHeaderData("", headerSpecs)
+	}
+	defer file.Close()
+
+	buffer := make([]byte, maxHeaderBytes)
+	n, readErr := file.Read(buffer)
+	if readErr != nil && readErr != io.EOF {
+		// Process whatever was read, even on error.
+		return processHeaderData(string(buffer[:n]), headerSpecs)
+	}
+
+	return processHeaderData(string(buffer[:n]), headerSpecs)
+}
+
+// processHeaderData extracts and cleans header values from a given string content.
+func processHeaderData(fileDataString string, headerSpecs map[string]string) (map[string]string, error) {
+	fileDataString = strings.ReplaceAll(fileDataString, "\r", "\n")
+	extractedValues := make(map[string]string)
+
+	for fieldName, headerTextInFile := range headerSpecs {
+		pattern := fmt.Sprintf(`(?im)^(?:[ \t]*<\?php)?[ \t/*#@]*%s:(.*)$`, regexp.QuoteMeta(headerTextInFile))
+
+		// Compile regex per iteration. For typical header counts, this is acceptable.
+		// If performance critical with many headers, consider pre-compiling or a single complex regex.
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error compiling regex for field %s (header: '%s'): %v. Pattern: %s\n", fieldName, headerTextInFile, err, pattern)
+			extractedValues[fieldName] = "" // Set to empty on regex compilation error
+			continue
+		}
+
+		matches := re.FindStringSubmatch(fileDataString)
+		var extractedVal string
+		if len(matches) > 1 && matches[1] != "" {
+			extractedVal = matches[1]
+			extractedVal = headerCleanupRe.ReplaceAllString(extractedVal, "")
+			extractedVal = strings.TrimSpace(extractedVal)
+		} else {
+			extractedVal = ""
+		}
+		extractedValues[fieldName] = extractedVal
+	}
+
+	return extractedValues, nil
+}
+
+// GetPluginHeaders retrieves headers for a WordPress plugin file.
+func GetPluginHeaders(filePath string) (PluginFileHeaders, error) {
+	rawHeaders, err := getRawFileHeaders(filePath, phpFileExtension, pluginFileHeaders)
+	if err != nil {
+		return PluginFileHeaders{}, err
+	}
+	if rawHeaders == nil {
+		return PluginFileHeaders{}, nil
+	}
+
+	headers := PluginFileHeaders{}
+	headers.Name = rawHeaders["Name"]
+	headers.PluginURI = rawHeaders["PluginURI"]
+	headers.Version = rawHeaders["Version"]
+	headers.Description = rawHeaders["Description"]
+	headers.Author = rawHeaders["Author"]
+	headers.AuthorURI = rawHeaders["AuthorURI"]
+	headers.TextDomain = rawHeaders["TextDomain"]
+	headers.DomainPath = rawHeaders["DomainPath"]
+	networkVal := rawHeaders["Network"]
+	if networkVal == "true" || networkVal == "1" {
+		headers.Network = true
+	}
+	headers.RequiresWP = rawHeaders["RequiresWP"]
+	headers.RequiresPHP = rawHeaders["RequiresPHP"]
+	headers.UpdateURI = rawHeaders["UpdateURI"]
+	headers.RequiresPlugins = rawHeaders["RequiresPlugins"]
+
+	return headers, nil
+}
+
+// GetThemeHeaders retrieves headers for a WordPress theme stylesheet.
+func GetThemeHeaders(filePath string) (ThemeFileHeaders, error) {
+	rawHeaders, err := getRawFileHeaders(filePath, cssFileExtension, themeFileHeaders)
+	if err != nil {
+		return ThemeFileHeaders{}, err
+	}
+	if rawHeaders == nil {
+		return ThemeFileHeaders{}, nil
+	}
+
+	headers := ThemeFileHeaders{}
+	headers.Name = rawHeaders["Name"]
+	headers.ThemeURI = rawHeaders["ThemeURI"]
+	headers.Description = rawHeaders["Description"]
+	headers.Author = rawHeaders["Author"]
+	headers.AuthorURI = rawHeaders["AuthorURI"]
+	headers.Version = rawHeaders["Version"]
+	headers.Template = rawHeaders["Template"]
+	headers.Status = rawHeaders["Status"]
+	headers.Tags = rawHeaders["Tags"]
+	headers.TextDomain = rawHeaders["TextDomain"]
+	headers.DomainPath = rawHeaders["DomainPath"]
+	headers.RequiresWP = rawHeaders["RequiresWP"]
+	headers.RequiresPHP = rawHeaders["RequiresPHP"]
+	headers.UpdateURI = rawHeaders["UpdateURI"]
+
+	return headers, nil
+}

--- a/pkg/wp/parser/wp-file-header.go
+++ b/pkg/wp/parser/wp-file-header.go
@@ -15,33 +15,49 @@ const (
 )
 
 type PluginFileHeaders struct {
+	Author          string
+	Description     string
+	License         string
 	PluginURI       string
 	Version         string
 	RequiresPHP     string
 	RequiresWP      string
 	RequiresPlugins []string
+	Tags            []string
 }
 
 var pluginFileHeaders = map[string]string{
+	"Author":          "Author",
+	"Description":     "Description",
+	"License":         "License",
 	"PluginURI":       "Plugin URI",
 	"Version":         "Version",
 	"RequiresPHP":     "Requires PHP",
 	"RequiresWP":      "Requires at least",
 	"RequiresPlugins": "Requires Plugins",
+	"Tags":            "Tags",
 }
 
 type ThemeFileHeaders struct {
+	Author      string
+	Description string
+	License     string
 	ThemeURI    string
 	Version     string
 	RequiresWP  string
 	RequiresPHP string
+	Tags        []string
 }
 
 var themeFileHeaders = map[string]string{
+	"Author":      "Author",
+	"Description": "Description",
+	"License":     "License",
 	"ThemeURI":    "Theme URI",
 	"Version":     "Version",
 	"RequiresWP":  "Requires at least",
 	"RequiresPHP": "Requires PHP",
+	"Tags":        "Tags",
 }
 
 var headerCleanupRe = regexp.MustCompile(`\s*(?:\*\/|\?>).*`)
@@ -117,10 +133,14 @@ func GetPluginHeaders(filePath string) (PluginFileHeaders, error) {
 	}
 
 	headers := PluginFileHeaders{}
+	headers.Author = rawHeaders["Author"]
+	headers.Description = rawHeaders["Description"]
+	headers.License = rawHeaders["License"]
 	headers.PluginURI = rawHeaders["PluginURI"]
 	headers.Version = rawHeaders["Version"]
 	headers.RequiresWP = rawHeaders["RequiresWP"]
 	headers.RequiresPHP = rawHeaders["RequiresPHP"]
+	headers.Tags = parseCommaSeparatedList(rawHeaders["Tags"])
 	headers.RequiresPlugins = parseCommaSeparatedList(rawHeaders["RequiresPlugins"])
 
 	return headers, nil
@@ -137,10 +157,14 @@ func GetThemeHeaders(filePath string) (ThemeFileHeaders, error) {
 	}
 
 	headers := ThemeFileHeaders{}
+	headers.Author = rawHeaders["Author"]
+	headers.Description = rawHeaders["Description"]
+	headers.License = rawHeaders["License"]
 	headers.ThemeURI = rawHeaders["ThemeURI"]
 	headers.Version = rawHeaders["Version"]
 	headers.RequiresWP = rawHeaders["RequiresWP"]
 	headers.RequiresPHP = rawHeaders["RequiresPHP"]
+	headers.Tags = parseCommaSeparatedList(rawHeaders["Tags"])
 
 	return headers, nil
 }

--- a/pkg/wpm/package.go
+++ b/pkg/wpm/package.go
@@ -13,7 +13,7 @@ type Config struct {
 	Name            string            `json:"name" validate:"required,min=3,max=164,package_name_regex"`
 	Description     string            `json:"description,omitempty"`
 	Private         bool              `json:"private,omitempty" validate:"boolean,omitempty"`
-	Type            string            `json:"type" validate:"required,oneof=plugin theme"`
+	Type            string            `json:"type" validate:"required,oneof=plugin theme mu-plugin"`
 	Version         string            `json:"version" validate:"required,package_semver,max=64"`
 	License         string            `json:"license" validate:"omitempty"`
 	Homepage        string            `json:"homepage,omitempty" validate:"omitempty,url"`
@@ -30,7 +30,7 @@ type Meta struct {
 	Tag        string `json:"tag"`
 	Dist       Dist   `json:"dist"`
 	Wpm        string `json:"_wpm"`
-	Access     string `json:"access"`
+	Visibility string `json:"visibility"`
 	Attachment string `json:"attachment"`
 	Readme     string `json:"readme,omitempty"`
 }

--- a/pkg/wpm/validator.go
+++ b/pkg/wpm/validator.go
@@ -66,7 +66,7 @@ func validateSemver(fl validator.FieldLevel) bool {
 		return false
 	}
 
-	_, err := semver.NewVersion(value)
+	_, err := semver.StrictNewVersion(value)
 
 	return err == nil
 }


### PR DESCRIPTION
- Add few parsers to:
    - Parse radme.txt file
    - Parse theme and plugin headers
- Add `--migrate` flag to determine b/w migration init and fresh init

Command examples:
```sh
wpm init --migrate --name amp --version 2.0.2
```