### PR TITLE
Make svn to wpm migration idempotent

### DIFF
--- a/cmd/svn-migrate/svn-migrate.go
+++ b/cmd/svn-migrate/svn-migrate.go
@@ -517,9 +517,11 @@ func migratePackage(ctx context.Context, pkgInfo *PackageInfo, manifest *Package
 		cancelTag()
 
 		manifest.Tags[rawVersionName] = tagManifestEntry
-		if tagManifestEntry.Status == statusSuccess {
+
+		switch tagManifestEntry.Status {
+		case statusSuccess:
 			result.TagsSucceededThisRun++
-		} else if tagManifestEntry.Status == statusFailed {
+		case statusFailed:
 			result.TagsFailedThisRun++
 		}
 
@@ -640,7 +642,8 @@ func processPackage(ctx context.Context, svnRepoPath, repoType, packageName stri
 		shouldFetchApi = true
 		l.Debug("refreshing api due to tag count change")
 	} else if !manifest.Qualified && manifest.ApiLookupDone &&
-		!(strings.Contains(manifest.ApiError, "(404)") || strings.Contains(manifest.ApiError, "plugin tags directory missing")) {
+		!strings.Contains(manifest.ApiError, "(404)") &&
+		!strings.Contains(manifest.ApiError, "plugin tags directory missing") {
 		l.Debugf("retrying api lookup: %s", manifest.ApiError)
 		shouldFetchApi = true
 	}


### PR DESCRIPTION
- Add proper logging
- Stop publishing to wpm registry if a package does not exists on dotorg api
- Add manifest file per package if the migration is done. It is useful once you have run migration on whole svn repo and want to it again for new revs.
- Add emojis for better visual representations on what is failing and what is passing. It's too hard to get an status from loads of logs.