### PR TITLE
Update file perms in tarball

### DIFF
--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -3,7 +3,6 @@
 package archive
 
 import (
-	"os"
 	"syscall"
 )
 
@@ -11,15 +10,6 @@ import (
 // it does not already have it. It is a no-op on platforms other than Windows.
 func addLongPathPrefix(srcPath string) string {
 	return srcPath
-}
-
-// chmodTarEntry is used to adjust the file permissions used in tar header based
-// on the platform the archival is done.
-func chmodTarEntry(perm os.FileMode) os.FileMode {
-	// Remove group- and world-writable bits.
-	perm &= ^os.FileMode(0o022)
-
-	return perm
 }
 
 func getInodeFromStat(stat interface{}) (inode uint64, err error) {

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"os"
 	"strings"
 )
 
@@ -21,16 +20,6 @@ func addLongPathPrefix(srcPath string) string {
 		return longPathPrefix + `UNC` + srcPath[1:]
 	}
 	return longPathPrefix + srcPath
-}
-
-// chmodTarEntry is used to adjust the file permissions used in tar header based
-// on the platform the archival is done.
-func chmodTarEntry(perm os.FileMode) os.FileMode {
-	// Remove group- and world-writable bits.
-	perm &= ^os.FileMode(0o022)
-
-	// Add the x bit: make everything +x on Windows
-	return perm | 0o111
 }
 
 func getInodeFromStat(stat interface{}) (inode uint64, err error) {


### PR DESCRIPTION
For portable tarballs, permissions are standardized to `0o644` for files and `0o755` for directories. This prevents source-dependent permission bits, ensuring consistent and appropriate access for the destination user.