### PR TITLE
Add validation for wildcard version

### DIFF
--- a/pkg/wpm/validator.go
+++ b/pkg/wpm/validator.go
@@ -111,6 +111,11 @@ func validateDependencies(fl validator.FieldLevel) bool {
 				return false
 			}
 		default:
+			// if version is wildcard, it is valid
+			if v == "*" {
+				continue
+			}
+
 			_, err := semver.NewVersion(v)
 			if err != nil {
 				return false


### PR DESCRIPTION
Allow usage of wildcard version constraint (`*`) in dependencies.