### PR TITLE
Handle idempotent response on tarball upload url

### DIFF
--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -60,8 +60,11 @@ type UploadTarballOptions struct {
 
 // UploadTarballResponse defines the response structure for uploading a package.
 type UploadTarballResponse struct {
-	Id  string `json:"id"`
-	Url string `json:"url"`
+	Id  *string `json:"id"`
+	Url *string `json:"url"`
+
+	// In case of idempotent requests, the message field may contain information.
+	Message *string `json:"message,omitempty"`
 }
 
 func (c *client) GetUploadTarballUrl(ctx context.Context, opts UploadTarballOptions) (UploadTarballResponse, error) {


### PR DESCRIPTION
If the package is already published, we need to ensure idempotency for the same user. This PR adds changes to bail early with idempotent response once the package is published for the same user. 