### PR TITLE
Update whoami path response

### DIFF
--- a/cli/command/publish/publish.go
+++ b/cli/command/publish/publish.go
@@ -199,7 +199,7 @@ func runPublish(ctx context.Context, wpmCli command.Cli, opts publishOptions) er
 	}
 
 	cfg := wpmCli.ConfigFile()
-	if cfg.AuthToken == "" || cfg.DefaultTId == "" {
+	if cfg.DefaultUser == "" || cfg.AuthToken == "" {
 		return errors.New("user must be logged in to perform this action")
 	}
 

--- a/pkg/config/configfile/file.go
+++ b/pkg/config/configfile/file.go
@@ -24,8 +24,6 @@ type ConfigFile struct {
 	Filename         string                       `json:"-"` // Note: for internal use only
 	AuthToken        string                       `json:"authToken,omitempty"`
 	DefaultUser      string                       `json:"defaultUser,omitempty"`
-	DefaultUId       string                       `json:"defaultUid,omitempty"`
-	DefaultTId       string                       `json:"defaultTid,omitempty"`
 	UsersAuthTokens  map[string]UsersAuthConfig   `json:"usersAuthTokens,omitempty"`
 	PluginsAuthToken map[string]PluginsAuthConfig `json:"pluginsAuthToken,omitempty"`
 }


### PR DESCRIPTION
`/-/whoami` route now only sends the username upon authentication as `plain/text` instead of `application/json` body. 