### PR TITLE
Restrict links and implement zip bomb detection

### DIFF
--- a/cli/command/install/run.go
+++ b/cli/command/install/run.go
@@ -120,7 +120,9 @@ func Run(ctx context.Context, cwd string, wpmCli command.Cli, opts RunOptions) e
 	}
 
 	// -- Actual Install --
-	inst := installer.New(absContentDir, opts.NetworkConcurrency, client)
+	inst := installer.New(absContentDir, opts.NetworkConcurrency, client, func(format string, args ...any) {
+		wpmCli.Output().ErrorWrite(fmt.Sprintf(format+"\n", args...))
+	})
 	if err := inst.InstallAll(ctx, plan, installerProgress(wpmCli.Output())); err != nil {
 		return errors.Wrap(err, "installation failed")
 	}

--- a/cli/command/publish/publish.go
+++ b/cli/command/publish/publish.go
@@ -62,9 +62,14 @@ func pack(path string, opts publishOptions, out *output.Output) (*archive.Tarbal
 		return nil, err
 	}
 
-	tar, err := archive.Tar(path, &archive.TarOptions{
+	tarOptions := &archive.TarOptions{
 		ExcludePatterns: ignorePatterns,
-	}, func(fileInfo os.FileInfo) {
+		Logger: func(format string, args ...any) {
+			out.ErrorWrite(fmt.Sprintf(format+"\n", args...))
+		},
+	}
+
+	tar, err := archive.Tar(path, tarOptions, func(fileInfo os.FileInfo) {
 		if opts.verbose {
 			sizeString := units.HumanSize(float64(fileInfo.Size()))
 			sizeString = fmt.Sprintf("%-7s", sizeString) // pad to 7 spaces since size string is capped to 4 numbers

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -27,6 +27,8 @@ const (
 	zstdMagicSkippableStart = 0x184D2A50
 	zstdMagicSkippableMask  = 0xFFFFFFF0
 
+	zstdMaxWindowSize = uint64(1 << 25) // 32 MB
+
 	maxCompressionRatio int64 = 250
 	ratioCheckThreshold int64 = 5 * 1024 * 1024   // 5 MB
 	maxDecompressedSize int64 = 512 * 1024 * 1024 // 512 MB
@@ -155,7 +157,7 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("unsupported archive format: expected zstd compressed archive")
 	}
 
-	zstdReader, err := zstd.NewReader(buf)
+	zstdReader, err := zstd.NewReader(buf, zstd.WithDecoderMaxWindow(zstdMaxWindowSize))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -27,8 +27,9 @@ const (
 	zstdMagicSkippableStart = 0x184D2A50
 	zstdMagicSkippableMask  = 0xFFFFFFF0
 
-	maxCompressionRatio = 250
-	maxUncompressedSize = 512 * 1024 * 1024
+	maxCompressionRatio int64 = 250
+	ratioCheckThreshold int64 = 5 * 1024 * 1024   // 5 MB
+	maxDecompressedSize int64 = 512 * 1024 * 1024 // 512 MB
 )
 
 var (
@@ -679,6 +680,47 @@ func createImpliedDirectories(dest string, hdr *tar.Header) error {
 	return nil
 }
 
+// readTracker wraps an io.Reader to track the total number of bytes read.
+type readTracker struct {
+	reader    io.Reader
+	bytesRead int64
+}
+
+func (t *readTracker) Read(p []byte) (int, error) {
+	n, err := t.reader.Read(p)
+	t.bytesRead += int64(n)
+	return n, err
+}
+
+// extractionLimiter wraps the decompressed stream and enforces size and ratio limits.
+type extractionLimiter struct {
+	decompressedStream io.Reader
+	compressedTracker  *readTracker
+	decompressedBytes  int64
+}
+
+func (b *extractionLimiter) Read(p []byte) (int, error) {
+	n, err := b.decompressedStream.Read(p)
+	b.decompressedBytes += int64(n)
+
+	if b.decompressedBytes > maxDecompressedSize {
+		return 0, fmt.Errorf("archive extraction failed: maximum decompressed size of 512MB exceeded (potential zip bomb)")
+	}
+
+	if b.decompressedBytes > ratioCheckThreshold {
+		cBytes := b.compressedTracker.bytesRead
+		if cBytes == 0 {
+			cBytes = 1 // prevent division by zero
+		}
+
+		if (b.decompressedBytes / cBytes) > maxCompressionRatio {
+			return 0, fmt.Errorf("archive extraction failed: maximum compression ratio of 250x exceeded (potential zip bomb)")
+		}
+	}
+
+	return n, err
+}
+
 // Untar reads a stream of bytes from `archive`, parses it as a tar archive,
 // and unpacks it into the directory at `dest`.
 func Untar(tarArchive io.Reader, dest string, options *TarOptions) error {
@@ -694,11 +736,18 @@ func Untar(tarArchive io.Reader, dest string, options *TarOptions) error {
 		options.ExcludePatterns = []string{}
 	}
 
-	decompressedArchive, err := DecompressStream(tarArchive)
+	compressedTracker := &readTracker{reader: tarArchive}
+
+	decompressedArchive, err := DecompressStream(compressedTracker)
 	if err != nil {
 		return err
 	}
 	defer decompressedArchive.Close()
 
-	return Unpack(decompressedArchive, dest, options)
+	detector := &extractionLimiter{
+		compressedTracker:  compressedTracker,
+		decompressedStream: decompressedArchive,
+	}
+
+	return Unpack(detector, dest, options)
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -619,6 +619,11 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 
 	var dirs []*tar.Header
 
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+
 	// Iterate through the files in the archive.
 loop:
 	for {
@@ -659,12 +664,13 @@ loop:
 		}
 
 		path := filepath.Join(dest, hdr.Name)
-		rel, err := filepath.Rel(dest, path)
-		if err != nil {
-			return err
-		}
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
+
+		parentDir := filepath.Dir(path)
+		if resolvedParentDir, err := filepath.EvalSymlinks(parentDir); err == nil {
+			rel, err := filepath.Rel(absDest, resolvedParentDir)
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				return breakoutError(fmt.Errorf("path escapes destination using symlink: %q", hdr.Name))
+			}
 		}
 
 		// If path exits we almost always just want to remove and replace it

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -701,11 +701,22 @@ type extractionLimiter struct {
 }
 
 func (b *extractionLimiter) Read(p []byte) (int, error) {
-	n, err := b.decompressedStream.Read(p)
+	if b.decompressedBytes > maxDecompressedSize {
+		return 0, fmt.Errorf("invalid archive: decompressed size exceeds 512MB limit (potential zip bomb)")
+	}
+
+	remaining := maxDecompressedSize - b.decompressedBytes
+	readBuf := p
+
+	if int64(len(readBuf)) > remaining {
+		readBuf = readBuf[:remaining+1]
+	}
+
+	n, err := b.decompressedStream.Read(readBuf)
 	b.decompressedBytes += int64(n)
 
 	if b.decompressedBytes > maxDecompressedSize {
-		return 0, fmt.Errorf("invalid archive: decompressed size exceeds 512MB limit (potential zip bomb)")
+		return n, fmt.Errorf("invalid archive: decompressed size exceeds 512MB limit (potential zip bomb)")
 	}
 
 	if b.decompressedBytes > ratioCheckThreshold {
@@ -714,8 +725,8 @@ func (b *extractionLimiter) Read(p []byte) (int, error) {
 			cBytes = 1 // prevent division by zero
 		}
 
-		if (b.decompressedBytes / cBytes) > maxCompressionRatio {
-			return 0, fmt.Errorf("invalid archive: compression ratio exceeds 99.6%% (potential zip bomb)")
+		if b.decompressedBytes >= int64(maxCompressionRatio)*cBytes {
+			return n, fmt.Errorf("invalid archive: compression ratio exceeds 99.6%% (potential zip bomb)")
 		}
 	}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -308,7 +309,11 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 
 	case tar.TypeLink, tar.TypeSymlink:
 		if options != nil && options.Logger != nil {
-			options.Logger("Warning: Skipped unsupported link at %q -> %q", path, hdr.Linkname)
+			if hdr.Typeflag == tar.TypeLink {
+				options.Logger("skipped hard link at %q -> %q", path, hdr.Linkname)
+			} else {
+				options.Logger("skipped symlink at %q -> %q", path, hdr.Linkname)
+			}
 		}
 
 		return nil
@@ -566,16 +571,11 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 
 	var dirs []*tar.Header
 
-	absDest, err := filepath.Abs(dest)
-	if err != nil {
-		return err
-	}
-
 	// Iterate through the files in the archive.
 loop:
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// end of tar archive
 			break
 		}
@@ -595,12 +595,11 @@ loop:
 
 		// Check for absolute paths or paths with ".." that would escape the destination directory
 		if !filepath.IsLocal(hdr.Name) {
-			return breakoutError(fmt.Errorf("invalid archive path: %q", hdr.Name))
+			return breakoutError(fmt.Errorf("invalid tarball with non-local file path %q", hdr.Name))
 		}
 
-		normalizedName := filepath.ToSlash(hdr.Name)
 		for _, exclude := range options.ExcludePatterns {
-			if strings.HasPrefix(normalizedName, exclude) {
+			if strings.HasPrefix(filepath.ToSlash(hdr.Name), filepath.ToSlash(exclude)) {
 				continue loop
 			}
 		}
@@ -612,13 +611,12 @@ loop:
 		}
 
 		path := filepath.Join(dest, hdr.Name)
-
-		parentDir := filepath.Dir(path)
-		if resolvedParentDir, err := filepath.EvalSymlinks(parentDir); err == nil {
-			rel, err := filepath.Rel(absDest, resolvedParentDir)
-			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-				return breakoutError(fmt.Errorf("path escapes destination using symlink: %q", hdr.Name))
-			}
+		rel, err := filepath.Rel(dest, path)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
 		}
 
 		// If path exits we almost always just want to remove and replace it
@@ -707,7 +705,7 @@ func (b *extractionLimiter) Read(p []byte) (int, error) {
 	b.decompressedBytes += int64(n)
 
 	if b.decompressedBytes > maxDecompressedSize {
-		return 0, fmt.Errorf("archive extraction failed: maximum decompressed size of 512MB exceeded (potential zip bomb)")
+		return 0, fmt.Errorf("invalid tarball with decompressed size exceeding 512MB (potential zip bomb)")
 	}
 
 	if b.decompressedBytes > ratioCheckThreshold {
@@ -717,7 +715,7 @@ func (b *extractionLimiter) Read(p []byte) (int, error) {
 		}
 
 		if (b.decompressedBytes / cBytes) > maxCompressionRatio {
-			return 0, fmt.Errorf("archive extraction failed: maximum compression ratio of 250x exceeded (potential zip bomb)")
+			return 0, fmt.Errorf("invalid tarball with compression ratio exceeding >99.6%% (potential zip bomb)")
 		}
 	}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -152,7 +152,7 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 
 	// check if the stream is compressed with zstd
 	if !isZstd(bs) {
-		return nil, fmt.Errorf("unsupported archive format, expected zstd compressed tarball")
+		return nil, fmt.Errorf("unsupported archive format: expected zstd compressed archive")
 	}
 
 	zstdReader, err := zstd.NewReader(buf)
@@ -231,7 +231,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	}
 
 	if fi.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("symlinks are not permitted in the archive, remove or replace the symlink at %s to continue", path)
+		return fmt.Errorf("cannot add %q: symlinks are not supported", path)
 	}
 
 	var link string
@@ -256,7 +256,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	// if it's not a directory and has more than 1 link, it's hard linked
 	// and we don't allow hard links in the archive, so return an error
 	if !fi.IsDir() && hasHardlinks(fi) {
-		return fmt.Errorf("hard links are not permitted in the archive, remove or replace the hard link at %s to continue", path)
+		return fmt.Errorf("cannot add %q: hard links are not supported", path)
 	}
 
 	if err := ta.TarWriter.WriteHeader(hdr); err != nil {
@@ -310,9 +310,9 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 	case tar.TypeLink, tar.TypeSymlink:
 		if options != nil && options.Logger != nil {
 			if hdr.Typeflag == tar.TypeLink {
-				options.Logger("skipped hard link at %q -> %q", path, hdr.Linkname)
+				options.Logger("\tskipping hard link: %q -> %q", path, hdr.Linkname)
 			} else {
-				options.Logger("skipped symlink at %q -> %q", path, hdr.Linkname)
+				options.Logger("\tskipping symlink: %q -> %q", path, hdr.Linkname)
 			}
 		}
 
@@ -322,7 +322,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 		return nil
 
 	default:
-		return fmt.Errorf("unhandled tar header type %d", hdr.Typeflag)
+		return fmt.Errorf("unhandled archive header type %d", hdr.Typeflag)
 	}
 
 	mTime := boundTime(hdr.ModTime)
@@ -395,12 +395,12 @@ func (t *Tarballer) Reader() io.ReadCloser {
 	return t.pipeReader
 }
 
-// FileCount returns the number of files added to the tarball.
+// FileCount returns the number of files added to the archive.
 func (t *Tarballer) FileCount() int64 {
 	return t.fileCount.Load()
 }
 
-// UnpackedSize returns the total size of the files added to the tarball.
+// UnpackedSize returns the total size of the files added to the archive.
 func (t *Tarballer) UnpackedSize() int64 {
 	return t.unpackedSize.Load()
 }
@@ -415,7 +415,7 @@ func (t *Tarballer) Do() {
 
 	defer func() {
 		if err := ta.TarWriter.Close(); err != nil && doErr == nil {
-			doErr = fmt.Errorf("failed to close tar writer: %w", err)
+			doErr = fmt.Errorf("failed to close archive writer: %w", err)
 		}
 
 		if err := t.compressWriter.Close(); err != nil && doErr == nil {
@@ -431,12 +431,12 @@ func (t *Tarballer) Do() {
 
 	stat, err := os.Lstat(t.srcPath)
 	if err != nil {
-		doErr = fmt.Errorf("unable to read source path %s: %s", t.srcPath, err)
+		doErr = fmt.Errorf("unable to read source path %q: %w", t.srcPath, err)
 		return
 	}
 
 	if !stat.IsDir() {
-		doErr = fmt.Errorf("source path %s is not a directory", t.srcPath)
+		doErr = fmt.Errorf("source path %q is not a directory", t.srcPath)
 		return
 	}
 
@@ -455,7 +455,7 @@ func (t *Tarballer) Do() {
 		walkRoot := filepath.Join(t.srcPath, include)
 		doErr = filepath.WalkDir(walkRoot, func(filePath string, f os.DirEntry, err error) error {
 			if err != nil {
-				return fmt.Errorf("unable to stat file %s: %s", t.srcPath, err)
+				return fmt.Errorf("unable to stat file %q: %w", t.srcPath, err)
 			}
 
 			relFilePath, err := filepath.Rel(t.srcPath, filePath)
@@ -487,7 +487,7 @@ func (t *Tarballer) Do() {
 					skip, matchInfo, err = t.pm.MatchesUsingParentResults(relFilePath, patternmatcher.MatchInfo{})
 				}
 				if err != nil {
-					doErr = fmt.Errorf("error matching %s: %v", relFilePath, err)
+					doErr = fmt.Errorf("error matching %q: %w", relFilePath, err)
 					return err
 				}
 
@@ -540,12 +540,12 @@ func (t *Tarballer) Do() {
 					return err
 				}
 
-				return fmt.Errorf("unable to add file %s to tar: %s", filePath, err)
+				return fmt.Errorf("unable to add file %q to archive: %w", filePath, err)
 			}
 
 			fileInfo, err := f.Info()
 			if err != nil {
-				return fmt.Errorf("unable to get file info for %s: %s", filePath, err)
+				return fmt.Errorf("unable to get file info for %q: %w", filePath, err)
 			}
 
 			if !f.IsDir() {
@@ -576,7 +576,7 @@ loop:
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
-			// end of tar archive
+			// end of archive
 			break
 		}
 		if err != nil {
@@ -595,7 +595,7 @@ loop:
 
 		// Check for absolute paths or paths with ".." that would escape the destination directory
 		if !filepath.IsLocal(hdr.Name) {
-			return breakoutError(fmt.Errorf("invalid tarball with non-local file path %q", hdr.Name))
+			return breakoutError(fmt.Errorf("invalid archive: insecure path %q (potential directory traversal)", hdr.Name))
 		}
 
 		for _, exclude := range options.ExcludePatterns {
@@ -705,7 +705,7 @@ func (b *extractionLimiter) Read(p []byte) (int, error) {
 	b.decompressedBytes += int64(n)
 
 	if b.decompressedBytes > maxDecompressedSize {
-		return 0, fmt.Errorf("invalid tarball with decompressed size exceeding 512MB (potential zip bomb)")
+		return 0, fmt.Errorf("invalid archive: decompressed size exceeds 512MB limit (potential zip bomb)")
 	}
 
 	if b.decompressedBytes > ratioCheckThreshold {
@@ -715,7 +715,7 @@ func (b *extractionLimiter) Read(p []byte) (int, error) {
 		}
 
 		if (b.decompressedBytes / cBytes) > maxCompressionRatio {
-			return 0, fmt.Errorf("invalid tarball with compression ratio exceeding >99.6%% (potential zip bomb)")
+			return 0, fmt.Errorf("invalid archive: compression ratio exceeds 99.6%% (potential zip bomb)")
 		}
 	}
 
@@ -726,7 +726,7 @@ func (b *extractionLimiter) Read(p []byte) (int, error) {
 // and unpacks it into the directory at `dest`.
 func Untar(tarArchive io.Reader, dest string, options *TarOptions) error {
 	if tarArchive == nil {
-		return fmt.Errorf("empty archive")
+		return errors.New("empty archive")
 	}
 
 	dest = filepath.Clean(dest)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,6 +38,7 @@ var (
 type TarOptions struct {
 	IncludeFiles    []string
 	ExcludePatterns []string
+	Logger          func(format string, args ...any)
 }
 
 // breakoutError is used to differentiate errors related to breaking out
@@ -280,7 +280,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	return nil
 }
 
-func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) error {
+func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, options *TarOptions) error {
 	hdrInfo := hdr.FileInfo()
 
 	switch hdr.Typeflag {
@@ -307,7 +307,10 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) e
 		file.Close()
 
 	case tar.TypeLink, tar.TypeSymlink:
-		log.Printf("Warning: Skipped unsupported link at %q -> %q", path, hdr.Linkname)
+		if options != nil && options.Logger != nil {
+			options.Logger("Warning: Skipped unsupported link at %q -> %q", path, hdr.Linkname)
+		}
+
 		return nil
 
 	case tar.TypeXGlobalHeader:
@@ -642,7 +645,7 @@ loop:
 			}
 		}
 
-		if err := createTarFile(path, dest, hdr, tr); err != nil {
+		if err := createTarFile(path, dest, hdr, tr, options); err != nil {
 			return err
 		}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,9 @@ const (
 	ImpliedDirectoryMode    = 0o755
 	zstdMagicSkippableStart = 0x184D2A50
 	zstdMagicSkippableMask  = 0xFFFFFFF0
+
+	maxCompressionRatio = 250
+	maxUncompressedSize = 512 * 1024 * 1024
 )
 
 var (
@@ -197,14 +201,10 @@ func FileInfoHeader(name string, fi os.FileInfo, link string) (*tar.Header, erro
 
 type tarAppender struct {
 	TarWriter *tar.Writer
-
-	// for hardlink mapping
-	SeenFiles map[uint64]string
 }
 
 func newTarAppender(writer io.Writer) *tarAppender {
 	return &tarAppender{
-		SeenFiles: make(map[uint64]string),
 		TarWriter: tar.NewWriter(writer),
 	}
 }
@@ -228,14 +228,11 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		return err
 	}
 
-	var link string
 	if fi.Mode()&os.ModeSymlink != 0 {
-		var err error
-		link, err = os.Readlink(path)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("symlinks are not permitted in the archive, remove or replace the symlink at %s to continue", path)
 	}
+
+	var link string
 
 	hdr, err := FileInfoHeader(name, fi, link)
 	if err != nil {
@@ -254,22 +251,10 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		hdr.Name = filepath.ToSlash(filepath.Join("package", originalHdrName))
 	}
 
-	// if it's not a directory and has more than 1 link,
-	// it's hard linked, so set the type flag accordingly
+	// if it's not a directory and has more than 1 link, it's hard linked
+	// and we don't allow hard links in the archive, so return an error
 	if !fi.IsDir() && hasHardlinks(fi) {
-		inode, err := getInodeFromStat(fi.Sys())
-		if err != nil {
-			return err
-		}
-		// a link should have a name that it links too
-		// and that linked name should be first in the tar archive
-		if oldpath, ok := ta.SeenFiles[inode]; ok {
-			hdr.Typeflag = tar.TypeLink
-			hdr.Linkname = oldpath
-			hdr.Size = 0 // This Must be here for the writer math to add up!
-		} else {
-			ta.SeenFiles[inode] = hdr.Name
-		}
+		return fmt.Errorf("hard links are not permitted in the archive, remove or replace the hard link at %s to continue", path)
 	}
 
 	if err := ta.TarWriter.WriteHeader(hdr); err != nil {
@@ -295,9 +280,6 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 }
 
 func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) error {
-	// hdr.Mode is in linux format, which we can use for sycalls,
-	// but for os.Foo() calls we need the mode converted to os.FileMode,
-	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
 	hdrInfo := hdr.FileInfo()
 
 	switch hdr.Typeflag {
@@ -313,7 +295,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) e
 	case tar.TypeReg:
 		// Source is regular file. We use sequential file access to avoid depleting
 		// the standby list on Windows. On Linux, this equates to a regular os.OpenFile.
-		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())
+		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdrInfo.Mode())
 		if err != nil {
 			return err
 		}
@@ -323,36 +305,9 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) e
 		}
 		file.Close()
 
-	case tar.TypeLink:
-		targetPath := filepath.Join(extractDir, hdr.Linkname)
-
-		// check for hardlink breakout
-		rel, err := filepath.Rel(extractDir, targetPath)
-		if err != nil || !filepath.IsLocal(rel) {
-			return breakoutError(fmt.Errorf("invalid hardlink %q -> %q", targetPath, hdr.Linkname))
-		}
-
-		if err := os.Link(targetPath, path); err != nil {
-			return err
-		}
-
-	case tar.TypeSymlink:
-		if filepath.IsAbs(hdr.Linkname) {
-			return breakoutError(fmt.Errorf("invalid symlink with absolute target %q -> %q", path, hdr.Linkname))
-		}
-
-		// 	path 				-> hdr.Linkname = targetPath
-		// e.g. /extractDir/path/to/symlink 	-> ../2/file	= /extractDir/path/2/file
-		targetPath := filepath.Join(filepath.Dir(path), hdr.Linkname)
-
-		rel, err := filepath.Rel(extractDir, targetPath)
-		if err != nil || !filepath.IsLocal(rel) {
-			return breakoutError(fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname))
-		}
-
-		if err := os.Symlink(hdr.Linkname, path); err != nil {
-			return err
-		}
+	case tar.TypeLink, tar.TypeSymlink:
+		log.Printf("Warning: Skipped unsupported link at %q -> %q", path, hdr.Linkname)
+		return nil
 
 	case tar.TypeXGlobalHeader:
 		return nil
@@ -361,25 +316,13 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) e
 		return fmt.Errorf("unhandled tar header type %d", hdr.Typeflag)
 	}
 
-	aTime := boundTime(latestTime(hdr.AccessTime, hdr.ModTime))
 	mTime := boundTime(hdr.ModTime)
+	aTime := boundTime(latestTime(hdr.AccessTime, hdr.ModTime))
 
-	// chtimes doesn't support a NOFOLLOW flag atm
-	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := chtimes(path, aTime, mTime); err != nil {
-				return err
-			}
-		}
-	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := chtimes(path, aTime, mTime); err != nil {
-			return err
-		}
-	} else {
-		if err := lchtimes(path, aTime, mTime); err != nil {
-			return err
-		}
+	if err := chtimes(path, aTime, mTime); err != nil {
+		return err
 	}
+
 	return nil
 }
 
@@ -651,8 +594,9 @@ loop:
 			return breakoutError(fmt.Errorf("invalid archive path: %q", hdr.Name))
 		}
 
+		normalizedName := filepath.ToSlash(hdr.Name)
 		for _, exclude := range options.ExcludePatterns {
-			if strings.HasPrefix(hdr.Name, exclude) {
+			if strings.HasPrefix(normalizedName, exclude) {
 				continue loop
 			}
 		}

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -2,22 +2,8 @@
 
 package archive
 
-import (
-	"syscall"
-)
-
 // addLongPathPrefix adds the Windows long path prefix to the path provided if
 // it does not already have it. It is a no-op on platforms other than Windows.
 func addLongPathPrefix(srcPath string) string {
 	return srcPath
-}
-
-func getInodeFromStat(stat interface{}) (inode uint64, err error) {
-	s, ok := stat.(*syscall.Stat_t)
-
-	if ok {
-		inode = s.Ino
-	}
-
-	return
 }

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -21,8 +21,3 @@ func addLongPathPrefix(srcPath string) string {
 	}
 	return longPathPrefix + srcPath
 }
-
-func getInodeFromStat(stat interface{}) (inode uint64, err error) {
-	// do nothing. no notion of Inode in stat on Windows
-	return
-}

--- a/pkg/archive/time_nonwindows.go
+++ b/pkg/archive/time_nonwindows.go
@@ -26,15 +26,3 @@ func timeToTimespec(time time.Time) (ts unix.Timespec) {
 	}
 	return unix.NsecToTimespec(time.UnixNano())
 }
-
-func lchtimes(name string, atime time.Time, mtime time.Time) error {
-	utimes := [2]unix.Timespec{
-		timeToTimespec(atime),
-		timeToTimespec(mtime),
-	}
-	err := unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
-	if err != nil && err != unix.ENOSYS {
-		return err
-	}
-	return err
-}

--- a/pkg/archive/time_nonwindows.go
+++ b/pkg/archive/time_nonwindows.go
@@ -5,8 +5,6 @@ package archive
 import (
 	"os"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 // chtimes changes the access time and modified time of a file at the given path.
@@ -15,14 +13,4 @@ import (
 // case, Chtimes defaults to Unix Epoch, just in case.
 func chtimes(name string, atime time.Time, mtime time.Time) error {
 	return os.Chtimes(name, atime, mtime)
-}
-
-func timeToTimespec(time time.Time) (ts unix.Timespec) {
-	if time.IsZero() {
-		// Return UTIME_OMIT special value
-		ts.Sec = 0
-		ts.Nsec = (1 << 30) - 2
-		return
-	}
-	return unix.NsecToTimespec(time.UnixNano())
 }

--- a/pkg/archive/time_windows.go
+++ b/pkg/archive/time_windows.go
@@ -26,7 +26,3 @@ func chtimes(name string, atime time.Time, mtime time.Time) error {
 	c := windows.NsecToFiletime(mtime.UnixNano())
 	return windows.SetFileTime(h, &c, nil, nil)
 }
-
-func lchtimes(name string, atime time.Time, mtime time.Time) error {
-	return nil
-}

--- a/pkg/pm/installer/installer.go
+++ b/pkg/pm/installer/installer.go
@@ -29,9 +29,10 @@ type Installer struct {
 	client      registry.Client
 	extractSem  chan struct{}
 	keysJson    signatures.KeysJson
+	logger      func(format string, args ...any)
 }
 
-func New(contentDir string, concurrency int, client registry.Client) *Installer {
+func New(contentDir string, concurrency int, client registry.Client, logger func(format string, args ...any)) *Installer {
 	if concurrency <= 0 {
 		concurrency = 16
 	}
@@ -45,6 +46,7 @@ func New(contentDir string, concurrency int, client registry.Client) *Installer 
 		tmpDir:      tmpDir,
 		concurrency: concurrency,
 		extractSem:  make(chan struct{}, max(runtime.NumCPU(), 1)),
+		logger:      logger,
 	}
 }
 
@@ -158,7 +160,11 @@ func (i *Installer) unpackToStaging(r io.Reader) (string, string, error) {
 		return "", "", errors.Wrap(err, "failed to create temporary directory")
 	}
 
-	if err := archive.Untar(r, rootTemp, nil); err != nil {
+	opts := &archive.TarOptions{
+		Logger: i.logger,
+	}
+
+	if err := archive.Untar(r, rootTemp, opts); err != nil {
 		return "", rootTemp, errors.Wrap(err, "failed to extract tarball")
 	}
 


### PR DESCRIPTION
This update restricts the ability to pack tarballs with symlinks and hardlinks, and ensures these links are skipped while unpacking a tarball.

This decision was made after careful consideration regarding security, cross-platform distribution, and how the WordPress Zip API handles symlinks during extraction. Archive APIs and packages frequently receive security advisories related to how tarball contents can be exploited (such as directory traversal attacks). Properly mitigating these risks requires significant, ongoing maintenance and prevention.

Furthermore, there are virtually no legitimate use cases for hardlinks or symlinks within WordPress plugin or theme codebases. By completely restricting their packing and extraction, we proactively eliminate a potential attack vector and simplify the package manager's architecture.

On the security front, we’re also introducing automatic detection for zip bombs. To protect server resources from malicious archives designed to expand infinitely and crash the system, we’ve established strict new extraction limits.

From now on, a plugin or theme will be flagged as a zip bomb if its uncompressed size tops 512 MB, or if it has a wildly high compression ratio of 250:1 (99.6%). If you're wondering where that number comes from, we are following industry best practices. For example, Composer also marks packages as zip bombs if they exceed 99% compression.