### PR TITLE
Add formatting tools and configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,20 @@
 root = true
 
 [*]
-indent_size = 4
 charset = utf-8
+indent_size = 4
 end_of_line = lf
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{yml,sh}]
+[*.md]
+max_line_length = 80
+
+[*.yml]
+quote_type = single
+
+[*.{yml,sh,json}]
 indent_size = 2
 indent_style = space
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     groups:
       actions:
         patterns:
-          - "actions/*"
+          - 'actions/*'
     labels:
       - 'dependencies'
       - 'github-actions'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "^1.25"
+          go-version: '^1.25'
 
       - name: check dependencies
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,8 @@
 name: codeql
 
 on:
-  push: 
-    branches: 
+  push:
+    branches:
       - main
   pull_request:
     branches:
@@ -21,7 +21,7 @@ jobs:
     name: analyze
     runs-on: ubuntu-latest
     permissions:
-      contents:  read
+      contents: read
       security-events: write
     steps:
       - name: checkout
@@ -32,7 +32,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: "go.mod"
+          go-version-file: 'go.mod'
 
       - name: initialize codeql
         uses: github/codeql-action/init@b71f5aebfc5cee7388c9d7b75e6e36f47787eb9a #v4.31.10
@@ -44,5 +44,5 @@ jobs:
 
       - name: perform codeql analysis
         uses: github/codeql-action/analyze@b71f5aebfc5cee7388c9d7b75e6e36f47787eb9a #v4.31.10
-        with: 
-          category:  "/language:go"
+        with:
+          category: '/language:go'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # files
 !go.mod
 !go.sum
+!bun.lock
+!package.json
 !LICENSE
 !NOTICE.txt
 !.gitignore
@@ -13,12 +15,14 @@
 !README.md
 !docker-bake.hcl
 !Dockerfile
+!.oxfmtrc.json
 !.git-blame-ignore-revs
 
 # directories
 !cli
 !cmd
 !pkg
+!.vscode
 !install
 !.github
 !scripts

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: '2'
 linters:
   exclusions:
     generated: lax

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,12 @@
+{
+  "overrides": [
+    {
+      "files": [
+        "*.md"
+      ],
+      "options": {
+        "proseWrap": "always"
+      }
+    }
+  ]
+}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,9 +1,7 @@
 {
   "overrides": [
     {
-      "files": [
-        "*.md"
-      ],
+      "files": ["*.md"],
       "options": {
         "proseWrap": "always"
       }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "golang.go",
+    "oxc.oxc-vscode"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-  "recommendations": [
-    "golang.go",
-    "oxc.oxc-vscode"
-  ]
+  "recommendations": ["golang.go", "oxc.oxc-vscode"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,12 @@
 {
   // Go
   "go.lintTool": "golangci-lint-v2",
-  "go.lintFlags": [
-    "--path-mode=abs",
-    "--fast-only"
-  ],
+  "go.lintFlags": ["--path-mode=abs", "--fast-only"],
   "go.formatTool": "custom",
   "go.alternateTools": {
     "customFormatter": "golangci-lint-v2"
   },
-  "go.formatFlags": [
-    "fmt",
-    "--stdin"
-  ],
+  "go.formatFlags": ["fmt", "--stdin"],
   "go.diagnostic.vulncheck": "Imports",
   // Oxc
   "editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  // Go
+  "go.lintTool": "golangci-lint-v2",
+  "go.lintFlags": [
+    "--path-mode=abs",
+    "--fast-only"
+  ],
+  "go.formatTool": "custom",
+  "go.alternateTools": {
+    "customFormatter": "golangci-lint-v2"
+  },
+  "go.formatFlags": [
+    "fmt",
+    "--stdin"
+  ],
+  "go.diagnostic.vulncheck": "Imports",
+  // Oxc
+  "editor.codeActionsOnSave": {
+    "source.fixAll.oxc": "always"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,8 @@
   },
   "[json]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # wpm
 
-`wpm` is a package manager designed to manage WordPress plugins and themes as packages, similar to how npm works for Node.js or Composer for PHP.
+`wpm` is a package manager designed to manage WordPress plugins and themes as
+packages, similar to how npm works for Node.js or Composer for PHP.
 
 ## Table of Contents
 
@@ -8,10 +9,10 @@
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Usage](#usage)
-    - [Common Commands](#common-commands)
+  - [Common Commands](#common-commands)
 - [Configuration with wpm.json](#configuration-with-wpmjson)
-    - [Required Fields](#required-fields)
-    - [Optional Fields](#optional-fields)
+  - [Required Fields](#required-fields)
+  - [Optional Fields](#optional-fields)
 - [Excluding Files from Publishing](#excluding-files-from-publishing)
 - [Documentation](#documentation)
 - [Support](#support)
@@ -19,48 +20,61 @@
 
 ## Overview
 
-`wpm` provides a structured way to manage WordPress plugins and themes. It uses a `wpm.json` file to define package metadata, including dependencies, versioning, and other relevant information. The tool interacts with a remote registry (currently in a development/conceptual stage at `registry.wpm.so`) to publish and retrieve packages.
+`wpm` provides a structured way to manage WordPress plugins and themes. It uses
+a `wpm.json` file to define package metadata, including dependencies,
+versioning, and other relevant information. The tool interacts with a remote
+registry (currently in a development/conceptual stage at `registry.wpm.so`) to
+publish and retrieve packages.
 
 ## Installation
 
 **Linux and Mac**
+
 ```
 curl -fsSL https://wpm.so/install | bash
 ```
 
 **Windows**
+
 ```
 powershell -c "irm wpm.so/install.ps1|iex"
 ```
 
 **Docker**
+
 ```
 docker pull trywpm/cli
 ```
 
 **Go**
+
 ```
 go install go.wpm.so/cli/cmd/wpm@latest
 ```
 
 **Build from Source**
+
 ```bash
 git clone git@github.com:trywpm/cli.git wpm
 cd wpm
 go build -o wpm ./cmd/wpm
 ```
 
-or download the binaries from the [release](https://github.com/trywpm/cli/releases) page.
+or download the binaries from the
+[release](https://github.com/trywpm/cli/releases) page.
 
 ## Quick Start
 
 1. **Initialize a new package:**
+
    ```bash
    wpm init
    ```
+
    This will create a `wpm.json` file in your project.
 
 2. **Install dependencies:**
+
    ```bash
    wpm install
    ```
@@ -78,36 +92,38 @@ wpm [OPTIONS] COMMAND
 
 ### Common Commands
 
-* `auth`: Authenticate with the wpm registry
-  * `login`: Log in to the registry
-  * `logout`: Log out from the registry
+- `auth`: Authenticate with the wpm registry
+  - `login`: Log in to the registry
+  - `logout`: Log out from the registry
 
-* `init`: Initialize a new WordPress package
-  * Use `-y` or `--yes` to accept all defaults
+- `init`: Initialize a new WordPress package
+  - Use `-y` or `--yes` to accept all defaults
 
-* `install`: Install dependencies from `wpm.json`
-  * `--no-dev`: Skip installing dev dependencies
-  * `--ignore-scripts`: Do not run lifecycle scripts
-  * `--dry-run`: Simulate installation without making changes
-  * `--save-dev`: Save installed packages as dev dependencies
-  * `--save-prod`: Save installed packages as production dependencies (default)
-  * `--network-concurrency`: Set number of concurrent network requests (default 16)
+- `install`: Install dependencies from `wpm.json`
+  - `--no-dev`: Skip installing dev dependencies
+  - `--ignore-scripts`: Do not run lifecycle scripts
+  - `--dry-run`: Simulate installation without making changes
+  - `--save-dev`: Save installed packages as dev dependencies
+  - `--save-prod`: Save installed packages as production dependencies (default)
+  - `--network-concurrency`: Set number of concurrent network requests
+    (default 16)
 
-* `publish`: Publish a package to the registry
-  * `--dry-run`: Validate without publishing
-  * `--tag`: Set the package tag (default: latest)
-  * `--access`: Set access level (public/private)
-  * `--verbose`: Show detailed output
+- `publish`: Publish a package to the registry
+  - `--dry-run`: Validate without publishing
+  - `--tag`: Set the package tag (default: latest)
+  - `--access`: Set access level (public/private)
+  - `--verbose`: Show detailed output
 
-* `whoami`: Display the current logged-in user
+- `whoami`: Display the current logged-in user
 
 ### Global Options
 
-* `--config`: Location of client config files (default: `~/.wpm`)
-* `-D, --debug`: Enable debug mode
-* `-l, --log-level`: Set logging level (`debug`, `info`, `warn`, `error`, `fatal`)
-* `-v, --version`: Print version information
-* `-h, --help`: Show help
+- `--config`: Location of client config files (default: `~/.wpm`)
+- `-D, --debug`: Enable debug mode
+- `-l, --log-level`: Set logging level (`debug`, `info`, `warn`, `error`,
+  `fatal`)
+- `-v, --version`: Print version information
+- `-h, --help`: Show help
 
 Run `wpm COMMAND --help` for more information about a specific command.
 
@@ -117,61 +133,63 @@ The `wpm.json` file defines your package and its dependencies:
 
 ```json
 {
-  "name": "my-awesome-plugin",
-  "description": "A short description of my plugin",
-  "type": "plugin",
-  "version": "1.0.0",
-  "license": "GPL-2.0-or-later",
-  "requires": {
-    "wp": ">=6.0",
-    "php": ">=7.4"
-  },
-  "dependencies": {
-    "akismet": "*", // always fetch latest version
-    "hello-dolly": "1.7.2"
-  },
-  "devDependencies": {
-    "some-dev-plugin": "3.20.2"
-  },
-  "config": {
-    "bin-dir": "wp-bin",
-    "content-dir": "wp-content",
-    "runtime": {
-      "wp": "6.9",
-      "php": "8.2"
-    }
-  }
+	"name": "my-awesome-plugin",
+	"description": "A short description of my plugin",
+	"type": "plugin",
+	"version": "1.0.0",
+	"license": "GPL-2.0-or-later",
+	"requires": {
+		"wp": ">=6.0",
+		"php": ">=7.4"
+	},
+	"dependencies": {
+		"akismet": "*", // always fetch latest version
+		"hello-dolly": "1.7.2"
+	},
+	"devDependencies": {
+		"some-dev-plugin": "3.20.2"
+	},
+	"config": {
+		"bin-dir": "wp-bin",
+		"content-dir": "wp-content",
+		"runtime": {
+			"wp": "6.9",
+			"php": "8.2"
+		}
+	}
 }
 ```
 
 ### Required Fields
 
-* `name`: Package name (lowercase, alphanumeric, hyphens)
-* `type`: Either `plugin` or `theme`
-* `version`: SemVer compatible version
+- `name`: Package name (lowercase, alphanumeric, hyphens)
+- `type`: Either `plugin` or `theme`
+- `version`: SemVer compatible version
 
 ### Optional Fields
 
-* `description`: Brief package description
-* `private`: Set `true` to prevent accidental publishing
-* `license`: License identifier
-* `homepage`: URL to your package's homepage
-* `tags`: Keywords (maximum 5)
-* `dependencies`: Production dependencies
-* `devDependencies`: Development-only dependencies
-* `requires`: Minimum requirements which the package supports
-* `config`: Custom configuration options
+- `description`: Brief package description
+- `private`: Set `true` to prevent accidental publishing
+- `license`: License identifier
+- `homepage`: URL to your package's homepage
+- `tags`: Keywords (maximum 5)
+- `dependencies`: Production dependencies
+- `devDependencies`: Development-only dependencies
+- `requires`: Minimum requirements which the package supports
+- `config`: Custom configuration options
 
 ## Configuration Options
-* `bin-dir`: Directory for executable files (default: `wp-bin`)
-* `content-dir`: WordPress content directory (default: `wp-content`)
-* `runtime`: Runtime environment versions this project is geared to run on
-* `runtime.wp`: WordPress version (e.g., `6.7`, `6.8`, `6.9`)
-* `runtime.php`: PHP version (e.g., `7.4`, `8.0`, `8.1`, `8.2`)
+
+- `bin-dir`: Directory for executable files (default: `wp-bin`)
+- `content-dir`: WordPress content directory (default: `wp-content`)
+- `runtime`: Runtime environment versions this project is geared to run on
+- `runtime.wp`: WordPress version (e.g., `6.7`, `6.8`, `6.9`)
+- `runtime.php`: PHP version (e.g., `7.4`, `8.0`, `8.1`, `8.2`)
 
 ## Excluding Files from Publishing
 
-Create a `.wpmignore` file in your project root to exclude files when publishing:
+Create a `.wpmignore` file in your project root to exclude files when
+publishing:
 
 ```
 node_modules/
@@ -183,13 +201,16 @@ node_modules/
 
 ## Documentation
 
-*Documentation will be available soon on the docs.wpm.so site. For now, you can refer to the command line help for detailed usage instructions.*
+_Documentation will be available soon on the docs.wpm.so site. For now, you can
+refer to the command line help for detailed usage instructions._
 
 ## Support
 
-* GitHub: [https://github.com/trywpm/cli/discussions](https://github.com/trywpm/cli/discussions)
-* Twitter: [@thelovekesh](https://twitter.com/thelovekesh)
+- GitHub:
+  [https://github.com/trywpm/cli/discussions](https://github.com/trywpm/cli/discussions)
+- Twitter: [@thelovekesh](https://twitter.com/thelovekesh)
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file
+for details.

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,54 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "devDependencies": {
+        "oxfmt": "0.51.0",
+      },
+    },
+  },
+  "packages": {
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.51.0", "", { "os": "android", "cpu": "arm" }, "sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.51.0", "", { "os": "android", "cpu": "arm64" }, "sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.51.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.51.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.51.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.51.0", "", { "os": "linux", "cpu": "arm" }, "sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.51.0", "", { "os": "linux", "cpu": "arm" }, "sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.51.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.51.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.51.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.51.0", "", { "os": "linux", "cpu": "none" }, "sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.51.0", "", { "os": "linux", "cpu": "none" }, "sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.51.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.51.0", "", { "os": "linux", "cpu": "x64" }, "sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.51.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.51.0", "", { "os": "none", "cpu": "arm64" }, "sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.51.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.51.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.51.0", "", { "os": "win32", "cpu": "x64" }, "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ=="],
+
+    "oxfmt": ["oxfmt@0.51.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.51.0", "@oxfmt/binding-android-arm64": "0.51.0", "@oxfmt/binding-darwin-arm64": "0.51.0", "@oxfmt/binding-darwin-x64": "0.51.0", "@oxfmt/binding-freebsd-x64": "0.51.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.51.0", "@oxfmt/binding-linux-arm-musleabihf": "0.51.0", "@oxfmt/binding-linux-arm64-gnu": "0.51.0", "@oxfmt/binding-linux-arm64-musl": "0.51.0", "@oxfmt/binding-linux-ppc64-gnu": "0.51.0", "@oxfmt/binding-linux-riscv64-gnu": "0.51.0", "@oxfmt/binding-linux-riscv64-musl": "0.51.0", "@oxfmt/binding-linux-s390x-gnu": "0.51.0", "@oxfmt/binding-linux-x64-gnu": "0.51.0", "@oxfmt/binding-linux-x64-musl": "0.51.0", "@oxfmt/binding-openharmony-arm64": "0.51.0", "@oxfmt/binding-win32-arm64-msvc": "0.51.0", "@oxfmt/binding-win32-ia32-msvc": "0.51.0", "@oxfmt/binding-win32-x64-msvc": "0.51.0" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "oxfmt": "0.51.0"
+  }
+}


### PR DESCRIPTION
Setup formatting tools and configs.

**Formatting and Editor Configuration**

* Updated `.editorconfig` to set specific formatting rules for different file types, such as maximum line length for Markdown files, single quotes for YAML, and 2-space indentation for YAML, shell, and JSON files.
* Added `.oxfmtrc.json` to enforce Markdown line wrapping and included `oxfmt` as a development dependency in `package.json` for formatting support. [[1]](diffhunk://#diff-ba6bdb5315b18041509bd0925c6394aa9250917b715ab46ca0a36231c566c8e5R1-R10) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1-R5)
* Added `.vscode/extensions.json` to recommend Go and Oxc extensions, and `.vscode/settings.json` to configure Go linting/formatting tools and set Oxc as the default formatter for Markdown, YAML, JSON, and JSONC files. [[1]](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912R1-R3) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R27)
* Changed `.golangci.yml` to use single quotes for the version field for consistency.

**Documentation Improvements**

* Reformatted `README.md` to wrap lines at 80 characters, improving readability and consistency, and updated command and configuration documentation for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R77) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R126) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R192) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L186-R216)

**Workflow and Dependency Updates**

* Standardized quoting style in GitHub Actions and Dependabot configuration files, switching from double to single quotes for better consistency. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L20-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL52-R52) [[3]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L35-R35) [[4]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L48-R48)