### PR TITLE
Remove mu-plugin as package type

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -69,7 +69,6 @@ func PackageTypes() cobra.CompletionFunc {
 	return FromList(
 		string(types.TypePlugin),
 		string(types.TypeTheme),
-		string(types.TypeMuPlugin),
 	)
 }
 

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -80,7 +80,7 @@ func NewInitCommand(wpmCli command.Cli) *cobra.Command {
 	flags.StringVar(&opts.name, "name", "", "Package name")
 	flags.StringVar(&opts.version, "version", "", "Semver-compliant version")
 	flags.StringVar(&opts.license, "license", "", "Package license")
-	flags.StringVar(&opts.packageType, "type", "", "Package type (plugin, theme, mu-plugin)")
+	flags.StringVar(&opts.packageType, "type", "", "Package type (plugin, theme)")
 
 	_ = cmd.RegisterFlagCompletionFunc("type", completion.PackageTypes())
 	_ = cmd.RegisterFlagCompletionFunc("license", completion.PackageLicenses())

--- a/docs/reference/cli/init.md
+++ b/docs/reference/cli/init.md
@@ -6,14 +6,14 @@ Initialize a new WordPress package or init wpm in existing project
 
 ### Options
 
-| Name          | Type     | Default | Description                             |
-|:--------------|:---------|:--------|:----------------------------------------|
-| `--existing`  | `bool`   |         | Init wpm.json for an existing project   |
-| `--license`   | `string` |         | Package license                         |
-| `--name`      | `string` |         | Package name                            |
-| `--type`      | `string` |         | Package type (plugin, theme, mu-plugin) |
-| `--version`   | `string` |         | Semver-compliant version                |
-| `-y`, `--yes` | `bool`   |         | Skip prompts and use default values     |
+| Name          | Type     | Default | Description                           |
+|:--------------|:---------|:--------|:--------------------------------------|
+| `--existing`  | `bool`   |         | Init wpm.json for an existing project |
+| `--license`   | `string` |         | Package license                       |
+| `--name`      | `string` |         | Package name                          |
+| `--type`      | `string` |         | Package type (plugin, theme)          |
+| `--version`   | `string` |         | Semver-compliant version              |
+| `-y`, `--yes` | `bool`   |         | Skip prompts and use default values   |
 
 
 <!---MARKER_GEN_END-->
@@ -69,7 +69,7 @@ automatically so the command can run without interaction.
 > When you run `wpm init -y` without `--type`, the `type` field is left
 > unset. Validation is skipped for that field in the `-y` path, so the command
 > succeeds, but you will need to set `type` manually before publishing. Prefer
-> `wpm init -y --type plugin` (or `theme`, `mu-plugin`) when scripting.
+> `wpm init -y --type plugin` (or `theme`) when scripting.
 
 ### Existing project mode (`--existing`)
 
@@ -89,19 +89,19 @@ Detection rules:
 
 Fields populated from the project sources:
 
-| wpm.json field | Source                                                     |
-| :------------- | :--------------------------------------------------------- |
-| `name`         | current directory name (override with `--name`)            |
-| `type`         | auto-detected (override with `--type`)                     |
-| `version`      | plugin header `Version` or theme header `Version`          |
-| `description`  | header `Description`, falling back to `readme.txt`         |
-| `license`      | header `License`, falling back to `readme.txt` `License`   |
-| `homepage`     | header `Plugin URI` or `Theme URI` (must be http/https)    |
-| `author`       | plugin or theme header `Author`                            |
-| `tags`         | `readme.txt` Tags, falling back to header `Tags`           |
-| `requires.wp`  | header `Requires at least` and `readme.txt` Requires       |
-| `requires.php` | header `Requires PHP` and `readme.txt` Requires PHP        |
-| `dependencies` | header `Requires Plugins` (each pinned to `*`)             |
+| wpm.json field | Source                                                   |
+| :------------- | :------------------------------------------------------- |
+| `name`         | current directory name (override with `--name`)          |
+| `type`         | auto-detected (override with `--type`)                   |
+| `version`      | plugin header `Version` or theme header `Version`        |
+| `description`  | header `Description`, falling back to `readme.txt`       |
+| `license`      | header `License`, falling back to `readme.txt` `License` |
+| `homepage`     | header `Plugin URI` or `Theme URI` (must be http/https)  |
+| `author`       | plugin or theme header `Author`                          |
+| `tags`         | `readme.txt` Tags, falling back to header `Tags`         |
+| `requires.wp`  | header `Requires at least` and `readme.txt` Requires     |
+| `requires.php` | header `Requires PHP` and `readme.txt` Requires PHP      |
+| `dependencies` | header `Requires Plugins` (each pinned to `*`)           |
 
 If a `readme.txt` exists but no `readme.md`, wpm also converts the
 WordPress.org-flavored `readme.txt` into a Markdown `readme.md` next to it.
@@ -114,8 +114,8 @@ Constraints applied automatically:
 - `description` is trimmed to at most 512 characters, preferring to cut at a
   sentence boundary.
 - `license` is cleared if it falls outside 3 to 100 characters.
-- `dependencies` from `Requires Plugins` are capped at 16, and any self-reference
-  is dropped.
+- `dependencies` from `Requires Plugins` are capped at 16, and any
+  self-reference is dropped.
 - `requires.wp` becomes `>=X` (and `<=Y` when `Tested up to` is also present and
   different from `Requires`).
 - `requires.php` becomes `>=X`.

--- a/docs/reference/cli/install.md
+++ b/docs/reference/cli/install.md
@@ -198,7 +198,7 @@ execution is not yet wired up.
   versions are rejected at validation time.
 - **Force a clean reinstall** when the tree is in a confusing state:
   ```sh
-  rm -rf wpm.lock wp-content/plugins wp-content/themes wp-content/mu-plugins
+  rm -rf wpm.lock wp-content/plugins wp-content/themes
   wpm install
   ```
   Review the new `wpm.lock` before committing.

--- a/docs/reference/cli/outdated.md
+++ b/docs/reference/cli/outdated.md
@@ -34,9 +34,8 @@ akismet [plugin]
 └── latest:  5.4.0 (minor update)
 ```
 
-- The first line shows the package name, its `[type]` (`plugin`, `theme`,
-  `mu-plugin`), and a faint `(dev)` marker when the package lives in
-  `devDependencies`.
+- The first line shows the package name, its `[type]` (`plugin` or `theme`), and
+  a faint `(dev)` marker when the package lives in `devDependencies`.
 - `current` is the version recorded in `wpm.lock`.
 - `latest` is what the registry returns for the `latest` tag.
 

--- a/docs/reference/cli/wpm.md
+++ b/docs/reference/cli/wpm.md
@@ -21,12 +21,12 @@ Package Manager for WordPress ecosystem
 
 ### Options
 
-| Name                | Type     | Default           | Description                                                       |
-|:--------------------|:---------|:------------------|:------------------------------------------------------------------|
-| `--config`          | `string` | `~/.wpm`          | Location of client config files                                   |
-| `-D`, `--debug`     | `bool`   |                   | Enable debug mode                                                 |
-| `-l`, `--log-level` | `string` | `info`            | Set the logging level ("debug", "info", "warn", "error", "fatal") |
-| `--registry`        | `string` | `registry.wpm.so` | Set specific registry to use                                      |
+| Name                | Type     | Default                  | Description                                                       |
+|:--------------------|:---------|:-------------------------|:------------------------------------------------------------------|
+| `--config`          | `string` | `~/.wpm`                 | Location of client config files                                   |
+| `-D`, `--debug`     | `bool`   |                          | Enable debug mode                                                 |
+| `-l`, `--log-level` | `string` | `info`                   | Set the logging level ("debug", "info", "warn", "error", "fatal") |
+| `--registry`        | `string` | `registry.wpm.so`        | Set specific registry to use                                      |
 
 
 <!---MARKER_GEN_END-->
@@ -40,9 +40,9 @@ Package Manager for WordPress ecosystem
 > breaking changes to CLI flags and to the `wpm.lock` format until 1.0.
 > Significant changes are called out in release notes.
 
-`wpm` is a package manager for the WordPress ecosystem. It treats plugins,
-themes, and must-use plugins as versioned packages you can install, publish, and
-depend on. If you've used npm or Composer, the model will feel familiar.
+`wpm` is a package manager for the WordPress ecosystem. It treats plugins and
+themes as versioned packages you can install, publish, and depend on. If you've
+used npm or Composer, the model will feel familiar.
 
 A wpm project is any directory that contains a `wpm.json` manifest. Most
 commands run against the current directory and produce or consume two files at
@@ -55,7 +55,7 @@ Installed packages land under `wp-content/` by default.
 | :------------------- | :-------------------------------------------------------------------------------------------- |
 | `wpm.json`           | Your package's manifest. Declares name, version, type, dependencies, and runtime constraints. |
 | `wpm.lock`           | A frozen snapshot of the resolved dependency tree. Commit this to version control.            |
-| `wp-content/`        | Where wpm extracts plugins, themes, and mu-plugins. Configurable via `config.content-dir`.    |
+| `wp-content/`        | Where wpm extracts plugins and themes. Configurable via `config.content-dir`.                 |
 | `.wpmignore`         | Optional gitignore-style file that excludes paths from `wpm publish`.                         |
 | `~/.wpm/config.json` | Your client config, including the auth token after `wpm auth login`.                          |
 

--- a/pkg/pm/installer/installer.go
+++ b/pkg/pm/installer/installer.go
@@ -374,8 +374,6 @@ func (i *Installer) getTargetDir(pkgType types.PackageType, name string) (string
 	switch pkgType {
 	case types.TypeTheme:
 		subDir = "themes"
-	case types.TypeMuPlugin:
-		subDir = "mu-plugins"
 	case types.TypePlugin:
 		subDir = "plugins"
 	default:

--- a/pkg/pm/installer/plan.go
+++ b/pkg/pm/installer/plan.go
@@ -90,8 +90,6 @@ func subDirForType(t types.PackageType) (string, bool) {
 	switch t {
 	case types.TypeTheme:
 		return "themes", true
-	case types.TypeMuPlugin:
-		return "mu-plugins", true
 	case types.TypePlugin:
 		return "plugins", true
 	default:

--- a/pkg/pm/wpmjson/types/types.go
+++ b/pkg/pm/wpmjson/types/types.go
@@ -9,7 +9,7 @@ func (pt PackageType) String() string {
 
 func (pt PackageType) Valid() bool {
 	switch pt {
-	case TypeTheme, TypePlugin, TypeMuPlugin:
+	case TypeTheme, TypePlugin:
 		return true
 	default:
 		return false
@@ -33,9 +33,8 @@ func (pv PackageVisibility) Valid() bool {
 }
 
 const (
-	TypeTheme    PackageType = "theme"
-	TypePlugin   PackageType = "plugin"
-	TypeMuPlugin PackageType = "mu-plugin"
+	TypeTheme  PackageType = "theme"
+	TypePlugin PackageType = "plugin"
 
 	VisibilityPublic  PackageVisibility = "public"
 	VisibilityPrivate PackageVisibility = "private"

--- a/pkg/pm/wpmjson/validator/validator.go
+++ b/pkg/pm/wpmjson/validator/validator.go
@@ -56,7 +56,7 @@ func IsValidDistTag(tag string) error {
 // IsValidPackageType checks if the package type is valid.
 func IsValidPackageType(t types.PackageType) error {
 	if !t.Valid() {
-		return errors.New("must be one of: theme, plugin, or mu-plugin")
+		return errors.New("must be one of: theme or plugin")
 	}
 	return nil
 }

--- a/schema.json
+++ b/schema.json
@@ -16,7 +16,7 @@
     },
     "type": {
       "type": "string",
-      "enum": ["theme", "plugin", "mu-plugin"],
+      "enum": ["theme", "plugin"],
       "description": "The type of package in the wp-content directory."
     },
     "description": {


### PR DESCRIPTION
This PR removes `mu-plugin` as a supported package type for security reasons.

Since must-use plugins are loaded directly by WordPress, allowing downloaded packages to be installed as `mu-plugin` creates a risk that untrusted code could be executed automatically at runtime. The potential impact of that risk is significant enough that we should not support this workflow.

There is also a usability concern. WordPress only loads PHP files placed directly in the `mu-plugins` directory. It does not automatically load plugins stored in subdirectories, which can lead to confusion when a package is installed but never loaded. Supporting directory-based `mu-plugin` packages would require an additional custom loader.

Users who want to deploy a plugin as a must-use plugin can still do so by using lifecycle scripts to move or copy the plugin into the desired location after installation.
