### PR TITLE
Remove wildcard versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The `wpm.json` file defines your package and its dependencies:
 		"php": ">=7.4"
 	},
 	"dependencies": {
-		"akismet": "*", // always fetch latest version
+		"akismet": "5.3.7",
 		"hello-dolly": "1.7.2"
 	},
 	"devDependencies": {

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -255,15 +255,11 @@ func runExistingInit(ctx context.Context, wpmCli command.Cli, opts *initOptions)
 		return err
 	}
 
-	wpmCfg := buildWpmConfig(ctx, *opts, opts.packageType, mainFileHeaders, readmeParser.GetMetadata(), resolveLatest)
-
-	if opts.name != "" {
-		wpmCfg.Name = opts.name
-	} else {
-		wpmCfg.Name = filepath.Base(cwd)
+	if opts.name == "" {
+		opts.name = filepath.Base(cwd)
 	}
 
-	removeSelfDependency(wpmCfg)
+	wpmCfg := buildWpmConfig(ctx, *opts, opts.packageType, mainFileHeaders, readmeParser.GetMetadata(), resolveLatest)
 
 	if err := resolveConfigVersion(wpmCli, wpmCfg, opts, extractedVersion); err != nil {
 		return err
@@ -539,6 +535,7 @@ func trimMeaningfully(s string, limit int) string {
 
 func buildWpmConfig(ctx context.Context, opts initOptions, pkgType string, mainFileHeaders any, readmeMeta map[string]any, resolve latestVersionResolver) *wpmjson.Config {
 	cfg := wpmjson.New()
+	cfg.Name = opts.name
 	cfg.Type = types.PackageType(pkgType)
 	cfg.License = getMetaString(readmeMeta, "license", opts.license)
 	cfg.Description = getMetaString(readmeMeta, "meta_description", "")
@@ -574,11 +571,13 @@ func buildWpmConfig(ctx context.Context, opts initOptions, pkgType string, mainF
 	}
 
 	dropInvalidMetadata(cfg)
+	removeCyclicDependency(cfg)
 	return cfg
 }
 
-// removeSelfDependency drops a dependency whose name matches the package itself.
-func removeSelfDependency(cfg *wpmjson.Config) {
+// removeCyclicDependency drops a dependency that points back to the package
+// itself.
+func removeCyclicDependency(cfg *wpmjson.Config) {
 	if cfg.Dependencies == nil {
 		return
 	}

--- a/cli/command/init/init.go
+++ b/cli/command/init/init.go
@@ -59,6 +59,9 @@ type existingProjectFiles struct {
 	wpmJson   string
 }
 
+// latestVersionResolver returns the latest published version of a package.
+type latestVersionResolver func(ctx context.Context, name string) (string, bool)
+
 func NewInitCommand(wpmCli command.Cli) *cobra.Command {
 	var opts initOptions
 
@@ -68,7 +71,7 @@ func NewInitCommand(wpmCli command.Cli) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.existing {
-				return runExistingInit(wpmCli, &opts)
+				return runExistingInit(cmd.Context(), wpmCli, &opts)
 			}
 			return runNewInit(cmd.Context(), wpmCli, &opts)
 		},
@@ -210,7 +213,7 @@ func resolveConfigVersion(wpmCli command.Cli, wpmCfg *wpmjson.Config, opts *init
 	return nil
 }
 
-func runExistingInit(wpmCli command.Cli, opts *initOptions) error {
+func runExistingInit(ctx context.Context, wpmCli command.Cli, opts *initOptions) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)
@@ -247,7 +250,12 @@ func runExistingInit(wpmCli command.Cli, opts *initOptions) error {
 		return err
 	}
 
-	wpmCfg := buildWpmConfig(*opts, opts.packageType, mainFileHeaders, readmeParser.GetMetadata())
+	resolveLatest, err := newRegistryResolver(wpmCli)
+	if err != nil {
+		return err
+	}
+
+	wpmCfg := buildWpmConfig(ctx, *opts, opts.packageType, mainFileHeaders, readmeParser.GetMetadata(), resolveLatest)
 
 	if opts.name != "" {
 		wpmCfg.Name = opts.name
@@ -529,7 +537,7 @@ func trimMeaningfully(s string, limit int) string {
 	return truncated
 }
 
-func buildWpmConfig(opts initOptions, pkgType string, mainFileHeaders any, readmeMeta map[string]any) *wpmjson.Config {
+func buildWpmConfig(ctx context.Context, opts initOptions, pkgType string, mainFileHeaders any, readmeMeta map[string]any, resolve latestVersionResolver) *wpmjson.Config {
 	cfg := wpmjson.New()
 	cfg.Type = types.PackageType(pkgType)
 	cfg.License = getMetaString(readmeMeta, "license", opts.license)
@@ -549,7 +557,7 @@ func buildWpmConfig(opts initOptions, pkgType string, mainFileHeaders any, readm
 	case parser.ThemeFileHeaders:
 		applyThemeHeaders(cfg, h, tags, &wpRequires, &phpRequires)
 	case parser.PluginFileHeaders:
-		applyPluginHeaders(cfg, h, tags, dependencies, &wpRequires, &phpRequires)
+		applyPluginHeaders(ctx, cfg, h, tags, dependencies, &wpRequires, &phpRequires, resolve)
 	}
 
 	cfg.Tags = sanitizeStringList(cfg.Tags, 5, 2, 64)
@@ -640,7 +648,15 @@ func applyThemeHeaders(cfg *wpmjson.Config, h parser.ThemeFileHeaders, tags []st
 
 // applyPluginHeaders fills config fields from a plugin's main file headers
 // and, additionally, populates the dependencies map from "Requires Plugins".
-func applyPluginHeaders(cfg *wpmjson.Config, h parser.PluginFileHeaders, tags []string, dependencies *types.Dependencies, wpRequires, phpRequires *string) {
+func applyPluginHeaders(
+	ctx context.Context,
+	cfg *wpmjson.Config,
+	h parser.PluginFileHeaders,
+	tags []string,
+	dependencies *types.Dependencies,
+	wpRequires, phpRequires *string,
+	resolve latestVersionResolver,
+) {
 	if cfg.License == "" {
 		cfg.License = h.License
 	}
@@ -664,15 +680,44 @@ func applyPluginHeaders(cfg *wpmjson.Config, h parser.PluginFileHeaders, tags []
 	if *phpRequires == "" && h.RequiresPHP != "" {
 		*phpRequires = h.RequiresPHP
 	}
-	for _, reqPlugin := range h.RequiresPlugins {
+	resolveRequiredPlugins(ctx, h.RequiresPlugins, dependencies, resolve)
+}
+
+// newRegistryResolver builds a latestVersionResolver.
+func newRegistryResolver(wpmCli command.Cli) (latestVersionResolver, error) {
+	client, err := wpmCli.RegistryClient()
+	if err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context, name string) (string, bool) {
+		pkg, err := client.GetPackageManifest(ctx, name, "latest", false)
+		if err != nil {
+			return "", false
+		}
+		return pkg.Version, true
+	}, nil
+}
+
+// resolveRequiredPlugins pins each "Requires Plugins" slug to its latest
+// published version from the registry.
+func resolveRequiredPlugins(ctx context.Context, plugins []string, dependencies *types.Dependencies, resolve latestVersionResolver) {
+	for _, reqPlugin := range plugins {
 		if len(*dependencies) >= validator.MaxDependencies {
 			break
 		}
+
+		reqPlugin = strings.ToLower(strings.TrimSpace(reqPlugin))
 		if err := validator.IsValidPackageName(reqPlugin); err != nil {
 			continue
 		}
-		// "Requires Plugins" header carries only slugs, so pin to "*".
-		(*dependencies)[reqPlugin] = "*"
+		latest, ok := resolve(ctx, reqPlugin)
+		if !ok {
+			continue
+		}
+		if err := validator.IsValidVersion(latest); err != nil {
+			continue
+		}
+		(*dependencies)[reqPlugin] = latest
 	}
 }
 

--- a/cli/command/init/init_test.go
+++ b/cli/command/init/init_test.go
@@ -27,8 +27,7 @@ func TestBuildWpmConfigDropsInvalidMetadata(t *testing.T) {
 		Tags:        []string{"good", "ba" + bad + "d"}, // one unsafe -> filtered
 	}
 
-	cfg := buildWpmConfig(context.Background(), initOptions{}, "plugin", headers, map[string]any{}, resolveTo("1.0.0"))
-	cfg.Name = "my-plugin"
+	cfg := buildWpmConfig(context.Background(), initOptions{name: "my-plugin"}, "plugin", headers, map[string]any{}, resolveTo("1.0.0"))
 	cfg.Version = "1.0.0"
 
 	if cfg.Author != "" {
@@ -53,16 +52,14 @@ func TestBuildWpmConfigDropsInvalidMetadata(t *testing.T) {
 
 func TestBuildWpmConfigCapsAndSanitizesDependencies(t *testing.T) {
 	required := make([]string, 0, 21)
-	required = append(required, "my-plugin") // self-reference, must be dropped
+	required = append(required, "my-plugin")
 	for i := range 20 {
 		required = append(required, fmt.Sprintf("dep-%02d", i))
 	}
 
 	headers := parser.PluginFileHeaders{RequiresPlugins: required}
-	cfg := buildWpmConfig(context.Background(), initOptions{}, "plugin", headers, map[string]any{}, resolveTo("1.0.0"))
-	cfg.Name = "my-plugin"
+	cfg := buildWpmConfig(context.Background(), initOptions{name: "my-plugin"}, "plugin", headers, map[string]any{}, resolveTo("1.0.0"))
 	cfg.Version = "1.0.0"
-	removeSelfDependency(cfg)
 
 	if cfg.Dependencies == nil {
 		t.Fatal("expected dependencies to be populated")
@@ -71,7 +68,7 @@ func TestBuildWpmConfigCapsAndSanitizesDependencies(t *testing.T) {
 		t.Errorf("expected at most 16 dependencies, got %d", n)
 	}
 	if _, ok := (*cfg.Dependencies)["my-plugin"]; ok {
-		t.Error("expected self-dependency to be removed")
+		t.Error("expected the cyclic self-dependency to be removed")
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -79,13 +76,13 @@ func TestBuildWpmConfigCapsAndSanitizesDependencies(t *testing.T) {
 	}
 }
 
-func TestRemoveSelfDependencyClearsEmptyMap(t *testing.T) {
+func TestRemoveCyclicDependencyClearsEmptyMap(t *testing.T) {
 	cfg := wpmjson.New()
 	cfg.Name = "solo"
 	deps := types.Dependencies{"solo": "1.0.0"}
 	cfg.Dependencies = &deps
 
-	removeSelfDependency(cfg)
+	removeCyclicDependency(cfg)
 
 	if cfg.Dependencies != nil {
 		t.Errorf("expected dependencies to be nil after removing the only entry, got %v", *cfg.Dependencies)
@@ -103,8 +100,7 @@ func TestBuildWpmConfigResolvesDependencyVersions(t *testing.T) {
 		return "", false
 	}
 
-	cfg := buildWpmConfig(context.Background(), initOptions{}, "plugin", headers, map[string]any{}, resolve)
-	cfg.Name = "host-plugin"
+	cfg := buildWpmConfig(context.Background(), initOptions{name: "host-plugin"}, "plugin", headers, map[string]any{}, resolve)
 	cfg.Version = "1.0.0"
 
 	if cfg.Dependencies == nil {

--- a/cli/command/init/init_test.go
+++ b/cli/command/init/init_test.go
@@ -1,6 +1,7 @@
 package init
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -12,6 +13,11 @@ import (
 
 func lineSeparator() string { return string(rune(0x2028)) }
 
+// resolveTo returns a latestVersionResolver that pins every package to version.
+func resolveTo(version string) latestVersionResolver {
+	return func(context.Context, string) (string, bool) { return version, true }
+}
+
 func TestBuildWpmConfigDropsInvalidMetadata(t *testing.T) {
 	bad := lineSeparator()
 	headers := parser.PluginFileHeaders{
@@ -21,7 +27,7 @@ func TestBuildWpmConfigDropsInvalidMetadata(t *testing.T) {
 		Tags:        []string{"good", "ba" + bad + "d"}, // one unsafe -> filtered
 	}
 
-	cfg := buildWpmConfig(initOptions{}, "plugin", headers, map[string]any{})
+	cfg := buildWpmConfig(context.Background(), initOptions{}, "plugin", headers, map[string]any{}, resolveTo("1.0.0"))
 	cfg.Name = "my-plugin"
 	cfg.Version = "1.0.0"
 
@@ -53,7 +59,7 @@ func TestBuildWpmConfigCapsAndSanitizesDependencies(t *testing.T) {
 	}
 
 	headers := parser.PluginFileHeaders{RequiresPlugins: required}
-	cfg := buildWpmConfig(initOptions{}, "plugin", headers, map[string]any{})
+	cfg := buildWpmConfig(context.Background(), initOptions{}, "plugin", headers, map[string]any{}, resolveTo("1.0.0"))
 	cfg.Name = "my-plugin"
 	cfg.Version = "1.0.0"
 	removeSelfDependency(cfg)
@@ -76,12 +82,62 @@ func TestBuildWpmConfigCapsAndSanitizesDependencies(t *testing.T) {
 func TestRemoveSelfDependencyClearsEmptyMap(t *testing.T) {
 	cfg := wpmjson.New()
 	cfg.Name = "solo"
-	deps := types.Dependencies{"solo": "*"}
+	deps := types.Dependencies{"solo": "1.0.0"}
 	cfg.Dependencies = &deps
 
 	removeSelfDependency(cfg)
 
 	if cfg.Dependencies != nil {
 		t.Errorf("expected dependencies to be nil after removing the only entry, got %v", *cfg.Dependencies)
+	}
+}
+
+func TestBuildWpmConfigResolvesDependencyVersions(t *testing.T) {
+	headers := parser.PluginFileHeaders{
+		RequiresPlugins: []string{"found-plugin", "missing-plugin"},
+	}
+	resolve := func(_ context.Context, name string) (string, bool) {
+		if name == "found-plugin" {
+			return "2.3.4", true
+		}
+		return "", false
+	}
+
+	cfg := buildWpmConfig(context.Background(), initOptions{}, "plugin", headers, map[string]any{}, resolve)
+	cfg.Name = "host-plugin"
+	cfg.Version = "1.0.0"
+
+	if cfg.Dependencies == nil {
+		t.Fatal("expected dependencies to be populated")
+	}
+	deps := *cfg.Dependencies
+	if got := deps["found-plugin"]; got != "2.3.4" {
+		t.Errorf("expected found-plugin pinned to resolved version 2.3.4, got %q", got)
+	}
+	if _, ok := deps["missing-plugin"]; ok {
+		t.Error("expected missing-plugin to be skipped when the registry has no latest version")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config with resolved dependencies should be valid, got: %v", err)
+	}
+}
+
+func TestResolveRequiredPluginsLowercasesSlugs(t *testing.T) {
+	resolve := func(_ context.Context, name string) (string, bool) {
+		if name == "woocommerce" {
+			return "8.5.0", true
+		}
+		return "", false
+	}
+
+	deps := types.Dependencies{}
+	resolveRequiredPlugins(context.Background(), []string{" WooCommerce "}, &deps, resolve)
+
+	if got, ok := deps["woocommerce"]; !ok || got != "8.5.0" {
+		t.Fatalf("expected lowercased woocommerce@8.5.0, got %q (present=%v)", got, ok)
+	}
+	if _, ok := deps["WooCommerce"]; ok {
+		t.Error("expected the original mixed-case key to be absent")
 	}
 }

--- a/cli/command/ls/ls.go
+++ b/cli/command/ls/ls.go
@@ -263,7 +263,7 @@ func (p *treePrinter) formatNode(name, requestedVersion string, isCycle bool) (i
 		info = name + "@" + pkg.Version
 	}
 
-	if pkg.Version != requestedVersion && requestedVersion != "*" {
+	if pkg.Version != requestedVersion {
 		invalid := "(invalid: \"" + requestedVersion + "\")"
 		if p.colorize {
 			invalid = aec.RedF.Apply(invalid)

--- a/docs/reference/cli/init.md
+++ b/docs/reference/cli/init.md
@@ -89,19 +89,19 @@ Detection rules:
 
 Fields populated from the project sources:
 
-| wpm.json field | Source                                                   |
-| :------------- | :------------------------------------------------------- |
-| `name`         | current directory name (override with `--name`)          |
-| `type`         | auto-detected (override with `--type`)                   |
-| `version`      | plugin header `Version` or theme header `Version`        |
-| `description`  | header `Description`, falling back to `readme.txt`       |
-| `license`      | header `License`, falling back to `readme.txt` `License` |
-| `homepage`     | header `Plugin URI` or `Theme URI` (must be http/https)  |
-| `author`       | plugin or theme header `Author`                          |
-| `tags`         | `readme.txt` Tags, falling back to header `Tags`         |
-| `requires.wp`  | header `Requires at least` and `readme.txt` Requires     |
-| `requires.php` | header `Requires PHP` and `readme.txt` Requires PHP      |
-| `dependencies` | header `Requires Plugins` (each pinned to `*`)           |
+| wpm.json field | Source                                                                   |
+| :------------- | :----------------------------------------------------------------------- |
+| `name`         | current directory name (override with `--name`)                          |
+| `type`         | auto-detected (override with `--type`)                                   |
+| `version`      | plugin header `Version` or theme header `Version`                        |
+| `description`  | header `Description`, falling back to `readme.txt`                       |
+| `license`      | header `License`, falling back to `readme.txt` `License`                 |
+| `homepage`     | header `Plugin URI` or `Theme URI` (must be http/https)                  |
+| `author`       | plugin or theme header `Author`                                          |
+| `tags`         | `readme.txt` Tags, falling back to header `Tags`                         |
+| `requires.wp`  | header `Requires at least` and `readme.txt` Requires                     |
+| `requires.php` | header `Requires PHP` and `readme.txt` Requires PHP                      |
+| `dependencies` | header `Requires Plugins` (each resolved to its latest registry version) |
 
 If a `readme.txt` exists but no `readme.md`, wpm also converts the
 WordPress.org-flavored `readme.txt` into a Markdown `readme.md` next to it.
@@ -114,8 +114,9 @@ Constraints applied automatically:
 - `description` is trimmed to at most 512 characters, preferring to cut at a
   sentence boundary.
 - `license` is cleared if it falls outside 3 to 100 characters.
-- `dependencies` from `Requires Plugins` are capped at 16, and any
-  self-reference is dropped.
+- `dependencies` from `Requires Plugins` are each resolved against the
+  registry's `latest` version and capped at 16. A self-reference, a package the
+  registry does not have, or an entry with an unusable version is dropped.
 - `requires.wp` becomes `>=X` (and `<=Y` when `Tested up to` is also present and
   different from `Requires`).
 - `requires.php` becomes `>=X`.

--- a/docs/reference/cli/ls.md
+++ b/docs/reference/cli/ls.md
@@ -66,9 +66,6 @@ The annotations on the right of each line tell you about the package's state:
 | `UNMET DEPENDENCY`         | Listed in `wpm.json` but missing from the lockfile. Run `wpm install`.                                   |
 | `(cycle)`                  | Cycle detected while expanding sub-dependencies; recursion stops here.                                   |
 
-The `(invalid: ...)` marker is skipped when `wpm.json` pins the package to `*`
-(any version), since any resolved version satisfies it.
-
 ### Limiting depth
 
 By default `wpm ls` expands the tree as deep as the lockfile goes. Pass

--- a/pkg/pm/registry/client.go
+++ b/pkg/pm/registry/client.go
@@ -97,7 +97,7 @@ func (c *client) PutPackage(ctx context.Context, data *manifest.Package, tarball
 func (c *client) GetPackageManifest(ctx context.Context, packageName, versionOrTag string, force bool) (*manifest.Package, error) {
 	var pkg *manifest.Package
 
-	if versionOrTag == "" || versionOrTag == "*" {
+	if versionOrTag == "" {
 		versionOrTag = "latest"
 	}
 

--- a/pkg/pm/wpmjson/validator/validator.go
+++ b/pkg/pm/wpmjson/validator/validator.go
@@ -130,9 +130,6 @@ func IsValidConstraint(v string) error {
 	if v != strings.TrimSpace(v) {
 		return errors.New("constraint cannot contain leading or trailing whitespace")
 	}
-	if v == "*" {
-		return nil
-	}
 	if strings.HasPrefix(v, "v") {
 		return errors.New("constraint cannot start with 'v'")
 	}
@@ -217,11 +214,7 @@ func ValidateDependencies(deps map[string]string, fieldName string) error {
 			errs.Add(fmt.Sprintf("%s[%s]", fieldName, name), err)
 		}
 
-		if version == "*" {
-			continue
-		}
-
-		// Dependencies version should be strict semver
+		// Dependencies version must be strict semver.
 		if err := IsValidVersion(version); err != nil {
 			errs.Add(fmt.Sprintf("%s[%s]", fieldName, name), err)
 		}

--- a/pkg/pm/wpmjson/validator/validator_test.go
+++ b/pkg/pm/wpmjson/validator/validator_test.go
@@ -74,7 +74,6 @@ func TestIsValidConstraint(t *testing.T) {
 		wantErr bool
 	}{
 		{"empty", "", true},
-		{"wildcard", "*", false},
 		{"v prefix", "v1.0.0", true},
 		{"range", ">=1.0.0 <2.0.0", false},
 		{"leading whitespace", " >=1.0.0", true},
@@ -88,6 +87,18 @@ func TestIsValidConstraint(t *testing.T) {
 				t.Fatalf("IsValidConstraint(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestValidateDependencies(t *testing.T) {
+	if err := ValidateDependencies(map[string]string{"akismet": "1.2.3"}, "dependencies"); err != nil {
+		t.Fatalf("expected exact semver dependency to be valid, got %v", err)
+	}
+	if err := ValidateDependencies(map[string]string{"akismet": "*"}, "dependencies"); err == nil {
+		t.Fatal("expected wildcard dependency version to be rejected")
+	}
+	if err := ValidateDependencies(map[string]string{"akismet": ">=1.0.0"}, "dependencies"); err == nil {
+		t.Fatal("expected range dependency version to be rejected")
 	}
 }
 
@@ -149,14 +160,14 @@ func TestIsValidAuthor(t *testing.T) {
 
 func TestValidateDependencyIntegrity(t *testing.T) {
 	t.Run("self dependency in deps", func(t *testing.T) {
-		err := ValidateDependencyIntegrity("my-pkg", map[string]string{"my-pkg": "*"}, nil)
+		err := ValidateDependencyIntegrity("my-pkg", map[string]string{"my-pkg": "1.0.0"}, nil)
 		if err == nil || !strings.Contains(err.Error(), "depend on itself") {
 			t.Fatalf("expected self-dependency error, got %v", err)
 		}
 	})
 
 	t.Run("self dependency in devDeps", func(t *testing.T) {
-		err := ValidateDependencyIntegrity("my-pkg", nil, map[string]string{"my-pkg": "*"})
+		err := ValidateDependencyIntegrity("my-pkg", nil, map[string]string{"my-pkg": "1.0.0"})
 		if err == nil || !strings.Contains(err.Error(), "depend on itself") {
 			t.Fatalf("expected self-dependency error, got %v", err)
 		}

--- a/pkg/pm/wpmjson/wpmjson_test.go
+++ b/pkg/pm/wpmjson/wpmjson_test.go
@@ -42,7 +42,7 @@ func TestConfigValidateAuthor(t *testing.T) {
 func TestConfigValidateDependencyIntegrity(t *testing.T) {
 	t.Run("cannot depend on itself", func(t *testing.T) {
 		cfg := baseConfig()
-		deps := types.Dependencies{"my-plugin": "*"}
+		deps := types.Dependencies{"my-plugin": "1.0.0"}
 		cfg.Dependencies = &deps
 
 		err := cfg.Validate()


### PR DESCRIPTION
The registry previously allowed `*` as a valid version specifier, which was automatically resolved to the `latest` version. However, updating packages to the latest version introduces several challenges, including version compatibility concerns and potential security risks. To address these issues, this PR removes support for wildcard versions and enforces the use of strict, explicit version specifications.
