### PR TITLE
Enable `GO_STRIP` in dist builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions: {}
 
 env:
   VERSION: ${{ github.ref }}
+  GO_STRIP: ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '' }}
 
 jobs:
   prepare:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,6 +7,9 @@ variable "VERSION" {
 variable "PACKAGER_NAME" {
 	default = "wpm team"
 }
+variable "GO_STRIP" {
+	default = ""
+}
 
 target "_common" {
 	args = {
@@ -44,6 +47,7 @@ target "binary" {
 	platforms = ["local"]
 	args = {
 		VERSION = VERSION
+		GO_STRIP = GO_STRIP
 		PACKAGER_NAME = PACKAGER_NAME
 	}
 }


### PR DESCRIPTION
Enabling `GO_STRIP` sets `-ldflags="-s -w"` in go build which:
- `-s`: strip symbol table
- `-w`: omit DWARF debug information